### PR TITLE
feat: 보낸 쿠폰 조회 기능을 구현한다.

### DIFF
--- a/backend/src/docs/asciidoc/coupon.adoc
+++ b/backend/src/docs/asciidoc/coupon.adoc
@@ -10,3 +10,7 @@ operation::coupon/received-coupons-not-used[snippets='http-request,http-response
 == 받은 쿠폰 조회 (사용함)
 
 operation::coupon/received-coupons-used[snippets='http-request,http-response']
+
+== 보낸 쿠폰 조회
+
+operation::coupon/sent-coupons[snippets='http-request,http-response']

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/application/CouponService.java
@@ -47,4 +47,11 @@ public class CouponService {
                 .map(CouponResponse::of)
                 .collect(Collectors.toList());
     }
+
+    public List<CouponResponse> getSentCoupons(final Long senderId) {
+        return couponQueryRepository.findBySenderId(senderId)
+                .stream()
+                .map(CouponResponse::of)
+                .collect(Collectors.toList());
+    }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/CouponQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/CouponQueryRepository.java
@@ -51,4 +51,21 @@ public class CouponQueryRepository {
                 .addValue("couponStatuses", couponStatuses);
         return jdbcTemplate.query(sql, parameters, ROW_MAPPER);
     }
+
+    public List<MemberCoupon> findBySenderId(final Long senderId) {
+        String sql = "SELECT c.id as coupon_id, "
+                + "s.id as sender_id, s.name as sender_name, "
+                + "s.email as sender_email, s.social_id as sender_social_id,"
+                + "s.image_url as sender_image_url,"
+                + "r.id as receiver_id, r.name as receiver_name, "
+                + "c.coupon_type, c.title, c.message, c.status "
+                + "FROM coupon as c "
+                + "JOIN member as s ON c.sender_id = s.id "
+                + "JOIN member as r ON c.receiver_id = r.id "
+                + "WHERE c.sender_id = :senderId "
+                + "ORDER BY c.id DESC";
+
+        SqlParameterSource parameters = new MapSqlParameterSource("senderId", senderId);
+        return jdbcTemplate.query(sql, parameters, ROW_MAPPER);
+    }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/presentation/CouponController.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/presentation/CouponController.java
@@ -29,8 +29,13 @@ public class CouponController {
     }
 
     @GetMapping("/received")
-    public ResponseEntity<List<CouponResponse>> receivedCoupons(@AuthenticationPrincipal final Long receivedId,
+    public ResponseEntity<List<CouponResponse>> receivedCoupons(@AuthenticationPrincipal final Long receiverId,
                                                                 @RequestParam final String status) {
-        return ResponseEntity.ok(couponService.getReceivedCoupons(receivedId, status));
+        return ResponseEntity.ok(couponService.getReceivedCoupons(receiverId, status));
+    }
+
+    @GetMapping("/sent")
+    public ResponseEntity<List<CouponResponse>> sentCoupons(@AuthenticationPrincipal final Long senderId) {
+        return ResponseEntity.ok(couponService.getSentCoupons(senderId));
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/acceptance/support/fixtures/CouponRequestFixture.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/acceptance/support/fixtures/CouponRequestFixture.java
@@ -14,7 +14,11 @@ public class CouponRequestFixture {
         return postWithToken("/api/coupons/send", accessToken, couponRequest);
     }
 
-    public static ExtractableResponse<Response> 쿠폰을_조회한다(final String accessToken, final String status) {
+    public static ExtractableResponse<Response> 받은_쿠폰을_조회한다(final String accessToken, final String status) {
         return getWithToken("/api/coupons/received?status=" + status, accessToken);
+    }
+
+    public static ExtractableResponse<Response> 보낸_쿠폰을_조회한다(final String accessToken) {
+        return getWithToken("/api/coupons/sent", accessToken);
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/application/CouponServiceTest.java
@@ -4,15 +4,15 @@ import static com.woowacourse.thankoo.common.fixtures.CouponFixture.MESSAGE;
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.NOT_USED;
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TITLE;
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TYPE;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_ID;
-import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
-import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
-import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_SOCIAL_ID;
-import static com.woowacourse.thankoo.common.fixtures.MemberFixture.IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -102,6 +102,24 @@ class CouponServiceTest {
                 new ContentRequest(TYPE, TITLE, MESSAGE)));
 
         List<CouponResponse> responses = couponService.getReceivedCoupons(receiver.getId(), NOT_USED);
+
+        assertAll(
+                () -> assertThat(responses).hasSize(1),
+                () -> assertThat(responses.get(0).getSender().getId()).isEqualTo(sender.getId()),
+                () -> assertThat(responses.get(0).getReceiver().getId()).isEqualTo(receiver.getId())
+        );
+    }
+
+    @DisplayName("보낸 쿠폰을 조회한다.")
+    @Test
+    void getSentCoupons() {
+        Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
+        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+
+        couponService.saveAll(sender.getId(), new CouponRequest(List.of(receiver.getId()),
+                new ContentRequest(TYPE, TITLE, MESSAGE)));
+
+        List<CouponResponse> responses = couponService.getSentCoupons(sender.getId());
 
         assertAll(
                 () -> assertThat(responses).hasSize(1),

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponQueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponQueryRepositoryTest.java
@@ -81,4 +81,21 @@ public class CouponQueryRepositoryTest {
 
         assertThat(memberCoupons).hasSize(2);
     }
+
+    @DisplayName("보낸 coupon 을 조회한다.")
+    @Test
+    void findBySenderId() {
+        Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
+        Member receiver = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, IMAGE_URL));
+        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
+                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.NOT_USED));
+        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
+                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.RESERVED));
+        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
+                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.USED));
+
+        List<MemberCoupon> memberCoupons = couponQueryRepository.findBySenderId(sender.getId());
+
+        assertThat(memberCoupons).hasSize(3);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/presentation/CouponControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/presentation/CouponControllerTest.java
@@ -169,4 +169,50 @@ public class CouponControllerTest extends ControllerTest {
                 )
         ));
     }
+
+    @DisplayName("보낸 쿠폰을 조회한다.")
+    @Test
+    void getSentCoupons() throws Exception {
+        given(jwtTokenProvider.getPayload(anyString()))
+                .willReturn("1");
+        Member huni = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL);
+        Member lala = new Member(2L, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL);
+
+        List<CouponResponse> couponResponses = List.of(
+                CouponResponse.of(new MemberCoupon(1L, huni, lala, TYPE, TITLE, MESSAGE, "USED")),
+                CouponResponse.of(new MemberCoupon(2L, huni, lala, TYPE, TITLE, MESSAGE, "EXPIRED"))
+        );
+
+        given(couponService.getSentCoupons(anyLong()))
+                .willReturn(couponResponses);
+        ResultActions resultActions = mockMvc.perform(get("/api/coupons/sent")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpectAll(
+                        status().isOk(),
+                        content().string(objectMapper.writeValueAsString(couponResponses)));
+
+        resultActions.andDo(document("coupon/sent-coupons",
+                getResponsePreprocessor(),
+                requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("token")
+                ),
+                responseFields(
+                        fieldWithPath("[].couponId").type(NUMBER).description("couponId"),
+                        fieldWithPath("[].sender.id").type(NUMBER).description("senderId"),
+                        fieldWithPath("[].sender.name").type(STRING).description("senderName"),
+                        fieldWithPath("[].sender.email").type(STRING).description("senderEmail"),
+                        fieldWithPath("[].sender.imageUrl").type(STRING).description("senderImageUrl"),
+                        fieldWithPath("[].receiver.id").type(NUMBER).description("receiverId"),
+                        fieldWithPath("[].receiver.name").type(STRING).description("receiverName"),
+                        fieldWithPath("[].receiver.email").type(STRING).description("receiverEmail"),
+                        fieldWithPath("[].receiver.imageUrl").type(STRING).description("receiverImageUrl"),
+                        fieldWithPath("[].content.couponType").type(STRING).description("couponType"),
+                        fieldWithPath("[].content.title").type(STRING).description("title"),
+                        fieldWithPath("[].content.message").type(STRING).description("message"),
+                        fieldWithPath("[].status").type(STRING).description("status")
+                )
+        ));
+    }
 }


### PR DESCRIPTION
## 상세 내용
- 보낸 쿠폰 조회 기능을 구현했습니다.
  - `/api/coupons/sent`
  
## 논의 사항
- 받은 쿠폰의 경우 `사용됨`, `사용전` 과 같은 상태에 따라 조회된다.
- 현재 보낸 쿠폰은 모든 쿠폰을 조회하도록 구현했는데, 보낸 쿠폰 또한 상태에 따라 조회되어야 할까요?

Close #66 

