### PR TITLE
feat: 하단 navigator로 페이지 연결(프로필, 받은 요청, 쿠폰보내기)

### DIFF
--- a/frontend/src/components/@shared/BottomNavBar.tsx
+++ b/frontend/src/components/@shared/BottomNavBar.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import MyPageButton from './MyPageButton';
+import ScheduledPageButton from './ScheduledPageButton';
+import SendButton from './SendButton';
+
+const buttons = [<MyPageButton />, <ScheduledPageButton />, <SendButton />];
+
+const BottomNavBar = () => {
+  return (
+    <S.Bar>
+      {buttons.map((button, idx) => {
+        return <S.Button key={idx}>{button}</S.Button>;
+      })}
+    </S.Bar>
+  );
+};
+
+const S = {
+  Bar: styled.div`
+    background-color: ${({ theme }) => theme.page.background};
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+
+    border-top: 2px solid ${({ theme }) => theme.page.color};
+    border-radius: 16px 16px 0 0;
+  `,
+  Button: styled.button`
+    width: 4rem;
+    height: 4rem;
+    color: white;
+    background-color: inherit;
+    border: none;
+  `,
+};
+
+export default BottomNavBar;

--- a/frontend/src/components/@shared/MyPageButton.tsx
+++ b/frontend/src/components/@shared/MyPageButton.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+import PersonIcon from '@mui/icons-material/Person';
+import { Link } from 'react-router-dom';
+import { ROUTE_PATH } from './../../constants/routes';
+
+const MyPageButton = () => {
+  return (
+    <Link to={`${ROUTE_PATH.PROFILE}`}>
+      <StyledButton />
+    </Link>
+  );
+};
+
+const StyledButton = styled(PersonIcon)`
+  transform: scale(1.4);
+  border-radius: 50%;
+  padding: 0.5rem;
+
+  transition: all ease-in;
+  transition-duration: 0.2s;
+  -webkit-transition-duration: 0.2s;
+
+  &:active {
+    background-color: ${({ theme }) => theme.button.active.background};
+  }
+`;
+
+export default MyPageButton;

--- a/frontend/src/components/@shared/ScheduledPageButton.tsx
+++ b/frontend/src/components/@shared/ScheduledPageButton.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+import EventAvailableIcon from '@mui/icons-material/EventAvailable';
+import { Link } from 'react-router-dom';
+import { ROUTE_PATH } from './../../constants/routes';
+
+const ScheduledPageButton = () => {
+  return (
+    <Link to={`${ROUTE_PATH.RESERVATIONS}`}>
+      <StyledButton />
+    </Link>
+  );
+};
+
+const StyledButton = styled(EventAvailableIcon)`
+  transform: scale(1.4);
+  border-radius: 50%;
+  padding: 0.5rem;
+
+  transition: all ease-in;
+  transition-duration: 0.2s;
+  -webkit-transition-duration: 0.2s;
+
+  &:active {
+    background-color: ${({ theme }) => theme.button.active.background};
+  }
+`;
+
+export default ScheduledPageButton;

--- a/frontend/src/components/@shared/SendButton.tsx
+++ b/frontend/src/components/@shared/SendButton.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+import SendIcon from '@mui/icons-material/Send';
+import { Link } from 'react-router-dom';
+import { ROUTE_PATH } from './../../constants/routes';
+
+const SendButton = () => {
+  return (
+    <Link to={`${ROUTE_PATH.SELECT_RECEIVER}`}>
+      <StyledButton fontSize='small' />
+    </Link>
+  );
+};
+
+const StyledButton = styled(SendIcon)`
+  transform: rotate(-45deg) scale(1.4);
+  border-radius: 50%;
+  padding: 0.5rem;
+
+  transition: all ease-in;
+  transition-duration: 0.2s;
+  -webkit-transition-duration: 0.2s;
+
+  &:active {
+    background-color: ${({ theme }) => theme.button.active.background};
+  }
+`;
+
+export default SendButton;

--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -1,5 +1,5 @@
 const BACK_SERVER = 'http://54.180.102.68';
-const DEV_SERVER = 'http://localhost:3000/';
+const DEV_SERVER = 'http://localhost:3000';
 
 export const BASE_URL = process.env.NODE_ENV === 'development' ? DEV_SERVER : BACK_SERVER;
 

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -1,17 +1,16 @@
 import styled from '@emotion/styled';
-import SendIcon from '@mui/icons-material/Send';
 import ArrowBackButton from '../components/@shared/ArrowBackButton';
 import TabsNav from '../components/@shared/TabsNav';
 import GridViewCoupons from '../components/Main/GridViewCoupons';
 import useMain from '../hooks/Main/useMain';
 
-import { Link } from 'react-router-dom';
 import Header from '../components/@shared/Header';
 import HeaderText from '../components/@shared/HeaderText';
-import PageLayout from '../components/@shared/PageLayout';
-import { couponTypeKeys, couponTypes } from '../types';
-import useModal from '../hooks/useModal';
 import Modal from '../components/@shared/Modal';
+import PageLayout from '../components/@shared/PageLayout';
+import useModal from '../hooks/useModal';
+import { couponTypeKeys, couponTypes } from '../types';
+import BottomNavBar from './../components/@shared/BottomNavBar';
 
 const Main = () => {
   const { setCurrentType, couponsByType, isLoading, error, currentType } = useMain();
@@ -35,10 +34,9 @@ const Main = () => {
         />
         {couponsByType && <GridViewCoupons coupons={couponsByType} />}
       </S.Body>
-      <Link to='/select-receiver'>
-        <S.NewCouponButton fontSize='small' />
-      </Link>
+
       {visible && <Modal />}
+      <BottomNavBar />
     </PageLayout>
   );
 };
@@ -49,26 +47,6 @@ const S = {
     flex-direction: column;
     gap: 1rem;
     padding: 15px;
-  `,
-  NewCouponButton: styled(SendIcon)`
-    position: absolute;
-    bottom: 3%;
-    right: 5%;
-    background-color: ${({ theme }) => theme.button.abled.background};
-    fill: ${({ theme }) => theme.button.abled.color};
-    border: 1px solid white;
-    padding: 0.7rem;
-    border-radius: 50%;
-    transform: rotate(-45deg) scale(1.4);
-    opacity: 0.9;
-    cursor: pointer;
-
-    &:hover {
-      background-color: ${({ theme }) => theme.button.active.background};
-      fill: ${({ theme }) => theme.button.active.color};
-      border-color: transparent;
-      opacity: 1;
-    }
   `,
 };
 


### PR DESCRIPTION
## 상세 내용
- 프로필, 받은 요청, 쿠폰보내기로 이동 가능한 네비게이터 구현

## 코드리뷰 중점사항
navigator에 버튼이 늘어날 것을 생각하여 버튼을 list안에 넣으면 바로 사용 추가 가능하도록 분리하였음

Close #103
