### PR TITLE
feat: 단일 쿠폰 조회 기능

### DIFF
--- a/backend/src/docs/asciidoc/coupon.adoc
+++ b/backend/src/docs/asciidoc/coupon.adoc
@@ -14,3 +14,7 @@ operation::coupons/received-coupons-used[snippets='http-request,http-response']
 == 보낸 쿠폰 조회
 
 operation::coupons/sent-coupons[snippets='http-request,http-response']
+
+== 단건 쿠폰 조회
+
+operation::coupons/get-coupon[snippets='http-request,http-response']

--- a/backend/src/main/java/com/woowacourse/thankoo/common/dto/TimeResponse.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/dto/TimeResponse.java
@@ -1,0 +1,25 @@
+package com.woowacourse.thankoo.common.dto;
+
+import com.woowacourse.thankoo.meeting.domain.MeetingTime;
+import java.time.LocalDateTime;
+import java.util.Locale;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class TimeResponse {
+
+    private LocalDateTime meetingTime;
+    private String timeZone;
+
+    public TimeResponse(final LocalDateTime meetingTime, final String timeZone) {
+        this.meetingTime = meetingTime;
+        this.timeZone = timeZone.toLowerCase(Locale.ROOT);
+    }
+
+    public static TimeResponse of(final MeetingTime meetingTime) {
+        return new TimeResponse(meetingTime.getTime(), meetingTime.getTimeZone());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
@@ -28,6 +28,7 @@ public enum ErrorType {
 
     INVALID_MEETING_MEMBER(5001, "잘못된 미팅 참여자입니다."),
     INVALID_MEETING_MEMBER_COUNT(5002, "미팅 참여자는 두 명이어야 합니다."),
+    NOT_FOUND_MEETING(5003, "존재하지 않는 미팅입니다."),
 
     UNHANDLED_EXCEPTION(9999, "예상치 못한 예외입니다.");
 

--- a/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
@@ -12,6 +12,7 @@ public enum ErrorType {
     NOT_FOUND_MEMBER(2001, "존재하지 않는 회원입니다."),
     INVALID_MEMBER_NAME(2002, "올바르지 않은 이름입니다."),
     INVALID_MEMBER_EMAIL(2003, "올바르지 않은 이메일 형식입니다."),
+    INVALID_MEMBER(2004, "올바르지 않은 회원입니다."),
 
     INVALID_COUPON_TYPE(3001, "존재하지 않는 쿠폰 타입입니다."),
     INVALID_COUPON_TITLE(3002, "잘못된 쿠폰 제목입니다."),

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/application/CouponQueryService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/application/CouponQueryService.java
@@ -1,0 +1,33 @@
+package com.woowacourse.thankoo.coupon.application;
+
+import com.woowacourse.thankoo.coupon.domain.CouponQueryRepository;
+import com.woowacourse.thankoo.coupon.domain.CouponStatusGroup;
+import com.woowacourse.thankoo.coupon.presentation.dto.CouponResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CouponQueryService {
+
+    private final CouponQueryRepository couponQueryRepository;
+
+    public List<CouponResponse> getReceivedCoupons(final Long receiverId, final String status) {
+        List<String> statusNames = CouponStatusGroup.findStatusNames(status);
+        return couponQueryRepository.findByReceiverIdAndStatus(receiverId, statusNames)
+                .stream()
+                .map(CouponResponse::of)
+                .collect(Collectors.toList());
+    }
+
+    public List<CouponResponse> getSentCoupons(final Long senderId) {
+        return couponQueryRepository.findBySenderId(senderId)
+                .stream()
+                .map(CouponResponse::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/application/CouponQueryService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/application/CouponQueryService.java
@@ -1,8 +1,15 @@
 package com.woowacourse.thankoo.coupon.application;
 
+import com.woowacourse.thankoo.common.exception.ErrorType;
 import com.woowacourse.thankoo.coupon.domain.CouponQueryRepository;
+import com.woowacourse.thankoo.coupon.domain.CouponStatus;
 import com.woowacourse.thankoo.coupon.domain.CouponStatusGroup;
+import com.woowacourse.thankoo.coupon.domain.MemberCoupon;
+import com.woowacourse.thankoo.coupon.exception.InvalidCouponException;
+import com.woowacourse.thankoo.coupon.infrastructure.TimeClient;
+import com.woowacourse.thankoo.coupon.presentation.dto.CouponDetailResponse;
 import com.woowacourse.thankoo.coupon.presentation.dto.CouponResponse;
+import com.woowacourse.thankoo.member.exception.InvalidMemberException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponQueryService {
 
     private final CouponQueryRepository couponQueryRepository;
+    private final TimeClient timeClient;
 
     public List<CouponResponse> getReceivedCoupons(final Long receiverId, final String status) {
         List<String> statusNames = CouponStatusGroup.findStatusNames(status);
@@ -29,5 +37,27 @@ public class CouponQueryService {
                 .stream()
                 .map(CouponResponse::of)
                 .collect(Collectors.toList());
+    }
+
+    public CouponDetailResponse getCouponDetail(final Long memberId, final Long couponId) {
+        MemberCoupon memberCoupon = getMemberCoupon(couponId);
+        validateCouponOwner(memberId, memberCoupon);
+
+        CouponStatus couponStatus = CouponStatus.of(memberCoupon.getStatus());
+        if (couponStatus.isInReserve()) {
+            return CouponDetailResponse.from(memberCoupon, timeClient.getTimeResponse(couponId, couponStatus));
+        }
+        return CouponDetailResponse.of(memberCoupon);
+    }
+
+    private MemberCoupon getMemberCoupon(final Long couponId) {
+        return couponQueryRepository.findByCouponId(couponId)
+                .orElseThrow(() -> new InvalidCouponException(ErrorType.NOT_FOUND_COUPON));
+    }
+
+    private void validateCouponOwner(final Long memberId, final MemberCoupon memberCoupon) {
+        if (!memberCoupon.isOwner(memberId)) {
+            throw new InvalidMemberException(ErrorType.INVALID_MEMBER);
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/application/CouponService.java
@@ -2,28 +2,22 @@ package com.woowacourse.thankoo.coupon.application;
 
 import com.woowacourse.thankoo.common.exception.ErrorType;
 import com.woowacourse.thankoo.coupon.application.dto.CouponRequest;
-import com.woowacourse.thankoo.coupon.domain.CouponQueryRepository;
 import com.woowacourse.thankoo.coupon.domain.CouponRepository;
-import com.woowacourse.thankoo.coupon.domain.CouponStatusGroup;
-import com.woowacourse.thankoo.coupon.presentation.dto.CouponResponse;
 import com.woowacourse.thankoo.member.domain.MemberRepository;
 import com.woowacourse.thankoo.member.exception.InvalidMemberException;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class CouponService {
 
     private final CouponRepository couponRepository;
-    private final CouponQueryRepository couponQueryRepository;
     private final MemberRepository memberRepository;
 
-    @Transactional
     public void saveAll(final Long senderId, final CouponRequest couponRequest) {
         validateMember(senderId, couponRequest.getReceiverIds());
         couponRepository.saveAll(couponRequest.toEntities(senderId));
@@ -38,20 +32,5 @@ public class CouponService {
     private boolean isExistMembers(final Long senderId, final List<Long> receiverIds) {
         return memberRepository.existsById(senderId)
                 && memberRepository.countByIdIn(receiverIds) == receiverIds.size();
-    }
-
-    public List<CouponResponse> getReceivedCoupons(final Long receiverId, final String status) {
-        List<String> statusNames = CouponStatusGroup.findStatusNames(status);
-        return couponQueryRepository.findByReceiverIdAndStatus(receiverId, statusNames)
-                .stream()
-                .map(CouponResponse::of)
-                .collect(Collectors.toList());
-    }
-
-    public List<CouponResponse> getSentCoupons(final Long senderId) {
-        return couponQueryRepository.findBySenderId(senderId)
-                .stream()
-                .map(CouponResponse::of)
-                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/CouponQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/CouponQueryRepository.java
@@ -2,7 +2,9 @@ package com.woowacourse.thankoo.coupon.domain;
 
 import com.woowacourse.thankoo.member.domain.Member;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -67,5 +69,25 @@ public class CouponQueryRepository {
 
         SqlParameterSource parameters = new MapSqlParameterSource("senderId", senderId);
         return jdbcTemplate.query(sql, parameters, ROW_MAPPER);
+    }
+
+    public Optional<MemberCoupon> findByCouponId(final Long couponId) {
+        String sql = "SELECT c.id as coupon_id, "
+                + "s.id as sender_id, s.name as sender_name, "
+                + "s.email as sender_email, s.social_id as sender_social_id,"
+                + "s.image_url as sender_image_url,"
+                + "r.id as receiver_id, r.name as receiver_name, "
+                + "c.coupon_type, c.title, c.message, c.status "
+                + "FROM coupon as c "
+                + "JOIN member as s ON c.sender_id = s.id "
+                + "JOIN member as r ON c.receiver_id = r.id "
+                + "WHERE c.id = :couponId ";
+
+        SqlParameterSource parameters = new MapSqlParameterSource("couponId", couponId);
+        try {
+            return Optional.ofNullable(jdbcTemplate.queryForObject(sql, parameters, ROW_MAPPER));
+        } catch (DataAccessException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/CouponStatus.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/CouponStatus.java
@@ -12,6 +12,10 @@ public enum CouponStatus {
         return this == NOT_USED;
     }
 
+    public boolean isInReserve() {
+        return isReserving() || this == RESERVED;
+    }
+
     public boolean isReserving() {
         return this == RESERVING;
     }

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/CouponStatus.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/CouponStatus.java
@@ -1,5 +1,9 @@
 package com.woowacourse.thankoo.coupon.domain;
 
+import com.woowacourse.thankoo.common.exception.ErrorType;
+import com.woowacourse.thankoo.coupon.exception.InvalidCouponStatusException;
+import java.util.Arrays;
+
 public enum CouponStatus {
 
     NOT_USED,
@@ -7,6 +11,13 @@ public enum CouponStatus {
     RESERVED,
     USED,
     EXPIRED;
+
+    public static CouponStatus of(final String name) {
+        return Arrays.stream(values())
+                .filter(value -> value.name().equalsIgnoreCase(name))
+                .findFirst()
+                .orElseThrow(() -> new InvalidCouponStatusException(ErrorType.INVALID_COUPON_STATUS));
+    }
 
     public boolean isNotUsed() {
         return this == NOT_USED;

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/MemberCoupon.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/MemberCoupon.java
@@ -1,6 +1,7 @@
 package com.woowacourse.thankoo.coupon.domain;
 
 import com.woowacourse.thankoo.member.domain.Member;
+import java.util.Objects;
 import lombok.Getter;
 
 @Getter
@@ -28,5 +29,42 @@ public class MemberCoupon {
         this.title = title;
         this.message = message;
         this.status = status;
+    }
+
+    public boolean isOwner(final Long memberId) {
+        return sender.isSameId(memberId) || receiver.isSameId(memberId);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MemberCoupon)) {
+            return false;
+        }
+        MemberCoupon that = (MemberCoupon) o;
+        return Objects.equals(couponId, that.couponId) && Objects.equals(sender, that.sender)
+                && Objects.equals(receiver, that.receiver) && Objects.equals(couponType,
+                that.couponType) && Objects.equals(title, that.title) && Objects.equals(message,
+                that.message) && Objects.equals(status, that.status);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(couponId, sender, receiver, couponType, title, message, status);
+    }
+
+    @Override
+    public String toString() {
+        return "MemberCoupon{" +
+                "couponId=" + couponId +
+                ", sender=" + sender.getId() +
+                ", receiver=" + receiver.getId() +
+                ", couponType='" + couponType + '\'' +
+                ", title='" + title + '\'' +
+                ", message='" + message + '\'' +
+                ", status='" + status + '\'' +
+                '}';
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/infrastructure/TimeClient.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/infrastructure/TimeClient.java
@@ -39,7 +39,7 @@ public class TimeClient {
     }
 
     private Reservation getReservation(final Long couponId) {
-        return reservationRepository.findTopByCoupon_IdAndReservationStatus(couponId, ReservationStatus.WAITING)
+        return reservationRepository.findTopByCouponIdAndReservationStatus(couponId, ReservationStatus.WAITING)
                 .orElseThrow(() -> new InvalidReservationException(ErrorType.NOT_FOUND_RESERVATION));
     }
 

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/infrastructure/TimeClient.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/infrastructure/TimeClient.java
@@ -1,0 +1,50 @@
+package com.woowacourse.thankoo.coupon.infrastructure;
+
+import com.woowacourse.thankoo.common.dto.TimeResponse;
+import com.woowacourse.thankoo.common.exception.ErrorType;
+import com.woowacourse.thankoo.coupon.domain.CouponStatus;
+import com.woowacourse.thankoo.coupon.exception.InvalidCouponStatusException;
+import com.woowacourse.thankoo.meeting.domain.Meeting;
+import com.woowacourse.thankoo.meeting.domain.MeetingRepository;
+import com.woowacourse.thankoo.meeting.domain.MeetingStatus;
+import com.woowacourse.thankoo.meeting.exception.InvalidMeetingException;
+import com.woowacourse.thankoo.reservation.domain.Reservation;
+import com.woowacourse.thankoo.reservation.domain.ReservationRepository;
+import com.woowacourse.thankoo.reservation.domain.ReservationStatus;
+import com.woowacourse.thankoo.reservation.exception.InvalidReservationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Component
+@RequiredArgsConstructor
+public class TimeClient {
+
+    private final ReservationRepository reservationRepository;
+    private final MeetingRepository meetingRepository;
+
+    public TimeResponse getTimeResponse(final Long couponId, final CouponStatus couponStatus) {
+        validateCouponStatus(couponStatus);
+        if (couponStatus.isReserving()) {
+            return TimeResponse.of(getReservation(couponId).getMeetingTime());
+        }
+        return TimeResponse.of(getMeeting(couponId).getMeetingTime());
+    }
+
+    private void validateCouponStatus(final CouponStatus couponStatus) {
+        if (!couponStatus.isInReserve()) {
+            throw new InvalidCouponStatusException(ErrorType.INVALID_COUPON_STATUS);
+        }
+    }
+
+    private Reservation getReservation(final Long couponId) {
+        return reservationRepository.findTopByCoupon_IdAndReservationStatus(couponId, ReservationStatus.WAITING)
+                .orElseThrow(() -> new InvalidReservationException(ErrorType.NOT_FOUND_RESERVATION));
+    }
+
+    private Meeting getMeeting(final Long couponId) {
+        return meetingRepository.findTopByCoupon_IdAndMeetingStatus(couponId, MeetingStatus.ON_PROGRESS)
+                .orElseThrow(() -> new InvalidMeetingException(ErrorType.NOT_FOUND_MEETING));
+    }
+}

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/presentation/CouponController.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/presentation/CouponController.java
@@ -4,11 +4,13 @@ import com.woowacourse.thankoo.authentication.presentation.AuthenticationPrincip
 import com.woowacourse.thankoo.coupon.application.CouponQueryService;
 import com.woowacourse.thankoo.coupon.application.CouponService;
 import com.woowacourse.thankoo.coupon.application.dto.CouponRequest;
+import com.woowacourse.thankoo.coupon.presentation.dto.CouponDetailResponse;
 import com.woowacourse.thankoo.coupon.presentation.dto.CouponResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -39,5 +41,11 @@ public class CouponController {
     @GetMapping("/sent")
     public ResponseEntity<List<CouponResponse>> sentCoupons(@AuthenticationPrincipal final Long senderId) {
         return ResponseEntity.ok(couponQueryService.getSentCoupons(senderId));
+    }
+
+    @GetMapping("/{couponId}")
+    public ResponseEntity<CouponDetailResponse> getCoupon(@AuthenticationPrincipal final Long memberId,
+                                                          @PathVariable final Long couponId) {
+        return ResponseEntity.ok(couponQueryService.getCouponDetail(memberId, couponId));
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/presentation/CouponController.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/presentation/CouponController.java
@@ -1,6 +1,7 @@
 package com.woowacourse.thankoo.coupon.presentation;
 
 import com.woowacourse.thankoo.authentication.presentation.AuthenticationPrincipal;
+import com.woowacourse.thankoo.coupon.application.CouponQueryService;
 import com.woowacourse.thankoo.coupon.application.CouponService;
 import com.woowacourse.thankoo.coupon.application.dto.CouponRequest;
 import com.woowacourse.thankoo.coupon.presentation.dto.CouponResponse;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CouponController {
 
     private final CouponService couponService;
+    private final CouponQueryService couponQueryService;
 
     @PostMapping("/send")
     public ResponseEntity<Void> send(@AuthenticationPrincipal final Long senderId,
@@ -31,11 +33,11 @@ public class CouponController {
     @GetMapping("/received")
     public ResponseEntity<List<CouponResponse>> receivedCoupons(@AuthenticationPrincipal final Long receiverId,
                                                                 @RequestParam final String status) {
-        return ResponseEntity.ok(couponService.getReceivedCoupons(receiverId, status));
+        return ResponseEntity.ok(couponQueryService.getReceivedCoupons(receiverId, status));
     }
 
     @GetMapping("/sent")
     public ResponseEntity<List<CouponResponse>> sentCoupons(@AuthenticationPrincipal final Long senderId) {
-        return ResponseEntity.ok(couponService.getSentCoupons(senderId));
+        return ResponseEntity.ok(couponQueryService.getSentCoupons(senderId));
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/presentation/dto/CouponDetailResponse.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/presentation/dto/CouponDetailResponse.java
@@ -1,0 +1,28 @@
+package com.woowacourse.thankoo.coupon.presentation.dto;
+
+import com.woowacourse.thankoo.common.dto.TimeResponse;
+import com.woowacourse.thankoo.coupon.domain.MemberCoupon;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class CouponDetailResponse {
+
+    private CouponResponse coupon;
+    private TimeResponse time;
+
+    private CouponDetailResponse(final CouponResponse coupon, final TimeResponse time) {
+        this.coupon = coupon;
+        this.time = time;
+    }
+
+    public static CouponDetailResponse from(final MemberCoupon memberCoupon, final TimeResponse timeResponse) {
+        return new CouponDetailResponse(CouponResponse.of(memberCoupon), timeResponse);
+    }
+
+    public static CouponDetailResponse of(final MemberCoupon memberCoupon) {
+        return new CouponDetailResponse(CouponResponse.of(memberCoupon), null);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/MeetingRepository.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/MeetingRepository.java
@@ -1,6 +1,9 @@
 package com.woowacourse.thankoo.meeting.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+
+    Optional<Meeting> findTopByCoupon_IdAndMeetingStatus(Long couponId, MeetingStatus status);
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/domain/Member.java
@@ -54,7 +54,11 @@ public class Member extends BaseEntity {
 
     public boolean hasSameId(final List<Long> ids) {
         return ids.stream()
-                .anyMatch(id::equals);
+                .anyMatch(this::isSameId);
+    }
+
+    public boolean isSameId(final Long id) {
+        return this.id.equals(id);
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/ReservationRepository.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/ReservationRepository.java
@@ -10,5 +10,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @EntityGraph(attributePaths = "coupon", type = EntityGraphType.LOAD)
     Optional<Reservation> findWithCouponById(Long reservationId);
 
-    Optional<Reservation> findTopByCoupon_IdAndReservationStatus(Long couponId, ReservationStatus status);
+    Optional<Reservation> findTopByCouponIdAndReservationStatus(Long couponId, ReservationStatus status);
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/ReservationRepository.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/ReservationRepository.java
@@ -9,4 +9,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     @EntityGraph(attributePaths = "coupon", type = EntityGraphType.LOAD)
     Optional<Reservation> findWithCouponById(Long reservationId);
+
+    Optional<Reservation> findTopByCoupon_IdAndReservationStatus(Long couponId, ReservationStatus status);
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/acceptance/support/fixtures/CouponRequestFixture.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/acceptance/support/fixtures/CouponRequestFixture.java
@@ -24,6 +24,10 @@ public class CouponRequestFixture {
         return getWithToken("/api/coupons/sent", accessToken);
     }
 
+    public static ExtractableResponse<Response> 쿠폰_단건_정보를_조회한다(final Long couponId, final String token) {
+        return getWithToken("api/coupons/" + couponId, token);
+    }
+
     public static CouponRequest createCouponRequest(final List<Long> receiverIds,
                                                     final String type,
                                                     final String title,

--- a/backend/src/test/java/com/woowacourse/thankoo/acceptance/support/fixtures/ReservationRequestFixture.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/acceptance/support/fixtures/ReservationRequestFixture.java
@@ -10,7 +10,6 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
 public class ReservationRequestFixture {
-
     public static ExtractableResponse<Response> 에약을_요청한다(final String token,
                                                          final ReservationRequest reservationRequest) {
         return postWithToken("/api/reservations", token, reservationRequest);

--- a/backend/src/test/java/com/woowacourse/thankoo/common/ControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/common/ControllerTest.java
@@ -7,6 +7,7 @@ import com.woowacourse.thankoo.authentication.application.AuthenticationService;
 import com.woowacourse.thankoo.authentication.infrastructure.JwtTokenProvider;
 import com.woowacourse.thankoo.authentication.presentation.AuthenticationContext;
 import com.woowacourse.thankoo.authentication.presentation.AuthenticationController;
+import com.woowacourse.thankoo.coupon.application.CouponQueryService;
 import com.woowacourse.thankoo.coupon.application.CouponService;
 import com.woowacourse.thankoo.coupon.presentation.CouponController;
 import com.woowacourse.thankoo.member.application.MemberService;
@@ -54,6 +55,9 @@ public class ControllerTest {
 
     @MockBean
     protected CouponService couponService;
+
+    @MockBean
+    protected CouponQueryService couponQueryService;
 
     @MockBean
     protected MemberService memberService;

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/application/CouponQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/application/CouponQueryServiceTest.java
@@ -8,21 +8,35 @@ import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_SOCIAL_ID;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.IMAGE_URL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_ID;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.thankoo.common.annotations.ApplicationTest;
+import com.woowacourse.thankoo.common.dto.TimeResponse;
 import com.woowacourse.thankoo.coupon.application.dto.ContentRequest;
 import com.woowacourse.thankoo.coupon.application.dto.CouponRequest;
+import com.woowacourse.thankoo.coupon.domain.Coupon;
+import com.woowacourse.thankoo.coupon.domain.CouponContent;
 import com.woowacourse.thankoo.coupon.domain.CouponRepository;
+import com.woowacourse.thankoo.coupon.domain.CouponStatus;
 import com.woowacourse.thankoo.coupon.presentation.dto.CouponResponse;
 import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.member.domain.MemberRepository;
+import com.woowacourse.thankoo.member.exception.InvalidMemberException;
+import com.woowacourse.thankoo.reservation.application.ReservationService;
+import com.woowacourse.thankoo.reservation.application.dto.ReservationRequest;
+import com.woowacourse.thankoo.reservation.domain.TimeZoneType;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -35,6 +49,9 @@ class CouponQueryServiceTest {
 
     @Autowired
     private CouponService couponService;
+
+    @Autowired
+    private ReservationService reservationService;
 
     @Autowired
     private CouponRepository couponRepository;
@@ -76,5 +93,61 @@ class CouponQueryServiceTest {
                 () -> assertThat(responses.get(0).getSender().getId()).isEqualTo(sender.getId()),
                 () -> assertThat(responses.get(0).getReceiver().getId()).isEqualTo(receiver.getId())
         );
+    }
+
+    @DisplayName("단일 쿠폰을 조회할 때 ")
+    @Nested
+    class CouponDetailTest {
+
+        @DisplayName("멤버가 쿠폰의 주인이 아니면 예외가 발생한다.")
+        @Test
+        void invalidMember() {
+            Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+            Member other = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+
+            Coupon coupon = couponRepository.save(new Coupon(sender.getId(),
+                    receiver.getId(),
+                    new CouponContent(TYPE, TITLE, MESSAGE),
+                    CouponStatus.NOT_USED));
+
+            assertThatThrownBy(() -> couponQueryService.getCouponDetail(other.getId(), coupon.getId()))
+                    .isInstanceOf(InvalidMemberException.class)
+                    .hasMessage("올바르지 않은 회원입니다.");
+        }
+
+        @DisplayName("쿠폰 상태가 예약 중일 때 시간을 함께 조회한다.")
+        @Test
+        void getCouponWithReserving() {
+            Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+
+            Coupon coupon = couponRepository.save(new Coupon(sender.getId(),
+                    receiver.getId(),
+                    new CouponContent(TYPE, TITLE, MESSAGE),
+                    CouponStatus.NOT_USED));
+
+            TimeResponse timeResponse = new TimeResponse(LocalDateTime.now().plusDays(1L),
+                    TimeZoneType.ASIA_SEOUL.getId());
+
+            reservationService.save(receiver.getId(),
+                    new ReservationRequest(coupon.getId(), timeResponse.getMeetingTime()));
+            assertThat(couponQueryService.getCouponDetail(receiver.getId(), coupon.getId())
+                    .getTime()).usingRecursiveComparison()
+                    .isEqualTo(timeResponse);
+        }
+
+        @DisplayName("쿠폰 상태가 사용되지 않았을 때 시간을 조회하지 않는다.")
+        @Test
+        void getCouponNoTime() {
+            Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+
+            Coupon coupon = couponRepository.save(new Coupon(sender.getId(),
+                    receiver.getId(),
+                    new CouponContent(TYPE, TITLE, MESSAGE),
+                    CouponStatus.NOT_USED));
+            assertThat(couponQueryService.getCouponDetail(receiver.getId(), coupon.getId()).getTime()).isNull();
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/application/CouponQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/application/CouponQueryServiceTest.java
@@ -132,6 +132,7 @@ class CouponQueryServiceTest {
 
             reservationService.save(receiver.getId(),
                     new ReservationRequest(coupon.getId(), timeResponse.getMeetingTime()));
+
             assertThat(couponQueryService.getCouponDetail(receiver.getId(), coupon.getId())
                     .getTime()).usingRecursiveComparison()
                     .isEqualTo(timeResponse);
@@ -147,6 +148,7 @@ class CouponQueryServiceTest {
                     receiver.getId(),
                     new CouponContent(TYPE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED));
+
             assertThat(couponQueryService.getCouponDetail(receiver.getId(), coupon.getId()).getTime()).isNull();
         }
     }

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/application/CouponQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/application/CouponQueryServiceTest.java
@@ -1,0 +1,80 @@
+package com.woowacourse.thankoo.coupon.application;
+
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.MESSAGE;
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.NOT_USED;
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TITLE;
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TYPE;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.IMAGE_URL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.thankoo.common.annotations.ApplicationTest;
+import com.woowacourse.thankoo.coupon.application.dto.ContentRequest;
+import com.woowacourse.thankoo.coupon.application.dto.CouponRequest;
+import com.woowacourse.thankoo.coupon.domain.CouponRepository;
+import com.woowacourse.thankoo.coupon.presentation.dto.CouponResponse;
+import com.woowacourse.thankoo.member.domain.Member;
+import com.woowacourse.thankoo.member.domain.MemberRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("CouponQueryService 는 ")
+@ApplicationTest
+class CouponQueryServiceTest {
+
+    @Autowired
+    private CouponQueryService couponQueryService;
+
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("받은 쿠폰을 조회한다.")
+    @Test
+    void getReceivedCoupons() {
+        Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
+        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+
+        couponService.saveAll(sender.getId(), new CouponRequest(List.of(receiver.getId()),
+                new ContentRequest(TYPE, TITLE, MESSAGE)));
+
+        List<CouponResponse> responses = couponQueryService.getReceivedCoupons(receiver.getId(), NOT_USED);
+
+        assertAll(
+                () -> assertThat(responses).hasSize(1),
+                () -> assertThat(responses.get(0).getSender().getId()).isEqualTo(sender.getId()),
+                () -> assertThat(responses.get(0).getReceiver().getId()).isEqualTo(receiver.getId())
+        );
+    }
+
+    @DisplayName("보낸 쿠폰을 조회한다.")
+    @Test
+    void getSentCoupons() {
+        Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
+        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+
+        couponService.saveAll(sender.getId(), new CouponRequest(List.of(receiver.getId()),
+                new ContentRequest(TYPE, TITLE, MESSAGE)));
+
+        List<CouponResponse> responses = couponQueryService.getSentCoupons(sender.getId());
+
+        assertAll(
+                () -> assertThat(responses).hasSize(1),
+                () -> assertThat(responses.get(0).getSender().getId()).isEqualTo(sender.getId()),
+                () -> assertThat(responses.get(0).getReceiver().getId()).isEqualTo(receiver.getId())
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/application/CouponServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/application/CouponServiceTest.java
@@ -1,7 +1,6 @@
 package com.woowacourse.thankoo.coupon.application;
 
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.MESSAGE;
-import static com.woowacourse.thankoo.common.fixtures.CouponFixture.NOT_USED;
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TITLE;
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TYPE;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
@@ -16,14 +15,12 @@ import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.thankoo.common.annotations.ApplicationTest;
 import com.woowacourse.thankoo.coupon.application.dto.ContentRequest;
 import com.woowacourse.thankoo.coupon.application.dto.CouponRequest;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.coupon.domain.CouponRepository;
-import com.woowacourse.thankoo.coupon.presentation.dto.CouponResponse;
 import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.member.domain.MemberRepository;
 import com.woowacourse.thankoo.member.exception.InvalidMemberException;
@@ -88,41 +85,5 @@ class CouponServiceTest {
                     .isInstanceOf(InvalidMemberException.class)
                     .hasMessage("존재하지 않는 회원입니다.");
         }
-    }
-
-    @DisplayName("받은 쿠폰을 조회한다.")
-    @Test
-    void getReceivedCoupons() {
-        Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
-        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
-
-        couponService.saveAll(sender.getId(), new CouponRequest(List.of(receiver.getId()),
-                new ContentRequest(TYPE, TITLE, MESSAGE)));
-
-        List<CouponResponse> responses = couponService.getReceivedCoupons(receiver.getId(), NOT_USED);
-
-        assertAll(
-                () -> assertThat(responses).hasSize(1),
-                () -> assertThat(responses.get(0).getSender().getId()).isEqualTo(sender.getId()),
-                () -> assertThat(responses.get(0).getReceiver().getId()).isEqualTo(receiver.getId())
-        );
-    }
-
-    @DisplayName("보낸 쿠폰을 조회한다.")
-    @Test
-    void getSentCoupons() {
-        Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
-        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
-
-        couponService.saveAll(sender.getId(), new CouponRequest(List.of(receiver.getId()),
-                new ContentRequest(TYPE, TITLE, MESSAGE)));
-
-        List<CouponResponse> responses = couponService.getSentCoupons(sender.getId());
-
-        assertAll(
-                () -> assertThat(responses).hasSize(1),
-                () -> assertThat(responses.get(0).getSender().getId()).isEqualTo(sender.getId()),
-                () -> assertThat(responses.get(0).getReceiver().getId()).isEqualTo(receiver.getId())
-        );
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponQueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponQueryRepositoryTest.java
@@ -12,6 +12,7 @@ import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_SOCIAL_ID;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.IMAGE_URL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.thankoo.common.annotations.RepositoryTest;
 import com.woowacourse.thankoo.member.domain.Member;
@@ -97,5 +98,21 @@ public class CouponQueryRepositoryTest {
         List<MemberCoupon> memberCoupons = couponQueryRepository.findBySenderId(sender.getId());
 
         assertThat(memberCoupons).hasSize(3);
+    }
+
+    @DisplayName("쿠폰을 조회한다.")
+    @Test
+    void findById() {
+        Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
+        Member receiver = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, IMAGE_URL));
+        Coupon coupon = couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
+                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.NOT_USED));
+
+        MemberCoupon memberCoupon = couponQueryRepository.findByCouponId(coupon.getId()).get();
+
+        assertAll(
+                () -> assertThat(memberCoupon).isNotNull(),
+                () -> assertThat(memberCoupon.getCouponId()).isEqualTo(coupon.getId())
+        );
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponStatusTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponStatusTest.java
@@ -4,9 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 @DisplayName("CouponStatus 는 ")
 class CouponStatusTest {
+
+    @DisplayName("쿠폰 상태를 조회한다.")
+    @ParameterizedTest(name = "{index} {displayName} name={0}, status={1}")
+    @CsvSource(value = {"not_used:NOT_USED", "reserving:RESERVING", "reserved:RESERVED", "used:USED",
+            "expired:EXPIRED"}, delimiter = ':')
+    void of(String name, CouponStatus status) {
+        assertThat(CouponStatus.of(name)).isSameAs(status);
+    }
 
     @DisplayName("쿠폰이 사용되지 않은 상태인지 확인한다.")
     @Test

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/infrastructure/TimeClientTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/infrastructure/TimeClientTest.java
@@ -91,6 +91,4 @@ class TimeClientTest {
             assertThat(timeResponse.getMeetingTime()).isEqualTo(meeting.getMeetingTime().getTime());
         }
     }
-
-
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/infrastructure/TimeClientTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/infrastructure/TimeClientTest.java
@@ -1,0 +1,96 @@
+package com.woowacourse.thankoo.coupon.infrastructure;
+
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.MESSAGE;
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TITLE;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.IMAGE_URL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
+import static com.woowacourse.thankoo.coupon.domain.CouponStatus.NOT_USED;
+import static com.woowacourse.thankoo.coupon.domain.CouponType.COFFEE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.thankoo.common.annotations.ApplicationTest;
+import com.woowacourse.thankoo.common.dto.TimeResponse;
+import com.woowacourse.thankoo.common.fixtures.ReservationFixture;
+import com.woowacourse.thankoo.coupon.domain.Coupon;
+import com.woowacourse.thankoo.coupon.domain.CouponContent;
+import com.woowacourse.thankoo.coupon.domain.CouponRepository;
+import com.woowacourse.thankoo.coupon.domain.CouponStatus;
+import com.woowacourse.thankoo.meeting.domain.Meeting;
+import com.woowacourse.thankoo.meeting.domain.MeetingRepository;
+import com.woowacourse.thankoo.meeting.domain.MeetingStatus;
+import com.woowacourse.thankoo.member.domain.Member;
+import com.woowacourse.thankoo.member.domain.MemberRepository;
+import com.woowacourse.thankoo.reservation.domain.Reservation;
+import com.woowacourse.thankoo.reservation.domain.ReservationRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("TimeClient 는 ")
+@ApplicationTest
+class TimeClientTest {
+
+    @Autowired
+    private TimeClient timeClient;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private MeetingRepository meetingRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @DisplayName("쿠폰으로 조회할 때 ")
+    @Nested
+    class GetTimeTest {
+
+        @DisplayName("예약 중이면 예약 정보를 조회한다.")
+        @Test
+        void getTimeResponseReservation() {
+            Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+            Coupon coupon = couponRepository.save(
+                    new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+            Reservation reservation = reservationRepository.save(
+                    ReservationFixture.createReservation(null, receiver, coupon));
+
+            TimeResponse timeResponse = timeClient.getTimeResponse(coupon.getId(), CouponStatus.RESERVING);
+            assertThat(timeResponse.getMeetingTime()).isEqualTo(reservation.getMeetingTime().getTime());
+        }
+
+        @DisplayName("예약 완료면 미팅 정보를 조회한다.")
+        @Test
+        void getTimeResponseMeeting() {
+            Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+            Coupon coupon = couponRepository.save(
+                    new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+            Reservation reservation = reservationRepository.save(
+                    ReservationFixture.createReservation(null, receiver, coupon));
+
+            Meeting meeting = meetingRepository.save(
+                    new Meeting(
+                            List.of(sender, receiver),
+                            reservation.getMeetingTime(),
+                            MeetingStatus.ON_PROGRESS,
+                            coupon)
+            );
+            TimeResponse timeResponse = timeClient.getTimeResponse(coupon.getId(), CouponStatus.RESERVED);
+            assertThat(timeResponse.getMeetingTime()).isEqualTo(meeting.getMeetingTime().getTime());
+        }
+    }
+
+
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/presentation/CouponControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/presentation/CouponControllerTest.java
@@ -91,7 +91,7 @@ public class CouponControllerTest extends ControllerTest {
                 CouponResponse.of(new MemberCoupon(2L, huni, lala, TYPE, TITLE, MESSAGE, "RESERVED"))
         );
 
-        given(couponService.getReceivedCoupons(anyLong(), anyString()))
+        given(couponQueryService.getReceivedCoupons(anyLong(), anyString()))
                 .willReturn(couponResponses);
         ResultActions resultActions = mockMvc.perform(get("/api/coupons/received?status=" + NOT_USED)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
@@ -137,7 +137,7 @@ public class CouponControllerTest extends ControllerTest {
                 CouponResponse.of(new MemberCoupon(2L, huni, lala, TYPE, TITLE, MESSAGE, "EXPIRED"))
         );
 
-        given(couponService.getReceivedCoupons(anyLong(), anyString()))
+        given(couponQueryService.getReceivedCoupons(anyLong(), anyString()))
                 .willReturn(couponResponses);
         ResultActions resultActions = mockMvc.perform(get("/api/coupons/received?status=" + USED)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
@@ -183,7 +183,7 @@ public class CouponControllerTest extends ControllerTest {
                 CouponResponse.of(new MemberCoupon(2L, huni, lala, TYPE, TITLE, MESSAGE, "EXPIRED"))
         );
 
-        given(couponService.getSentCoupons(anyLong()))
+        given(couponQueryService.getSentCoupons(anyLong()))
                 .willReturn(couponResponses);
         ResultActions resultActions = mockMvc.perform(get("/api/coupons/sent")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/presentation/CouponControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/presentation/CouponControllerTest.java
@@ -34,11 +34,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.woowacourse.thankoo.common.ControllerTest;
+import com.woowacourse.thankoo.common.dto.TimeResponse;
 import com.woowacourse.thankoo.coupon.application.dto.ContentRequest;
 import com.woowacourse.thankoo.coupon.application.dto.CouponRequest;
+import com.woowacourse.thankoo.coupon.domain.CouponStatus;
+import com.woowacourse.thankoo.coupon.domain.CouponType;
 import com.woowacourse.thankoo.coupon.domain.MemberCoupon;
+import com.woowacourse.thankoo.coupon.presentation.dto.CouponDetailResponse;
 import com.woowacourse.thankoo.coupon.presentation.dto.CouponResponse;
+import com.woowacourse.thankoo.meeting.domain.MeetingTime;
 import com.woowacourse.thankoo.member.domain.Member;
+import com.woowacourse.thankoo.reservation.domain.TimeZoneType;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.DisplayName;
@@ -212,6 +219,56 @@ public class CouponControllerTest extends ControllerTest {
                         fieldWithPath("[].content.title").type(STRING).description("title"),
                         fieldWithPath("[].content.message").type(STRING).description("message"),
                         fieldWithPath("[].status").type(STRING).description("status")
+                )
+        ));
+    }
+
+    @DisplayName("단일 쿠폰을 조회한다.")
+    @Test
+    void getCoupon() throws Exception {
+        given(jwtTokenProvider.getPayload(anyString()))
+                .willReturn("1");
+        Member huni = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL);
+        Member lala = new Member(2L, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL);
+
+        LocalDateTime localDateTime = LocalDateTime.now().plusDays(1L);
+        CouponDetailResponse couponDetailResponse = CouponDetailResponse.from(
+                new MemberCoupon(1L, huni, lala, CouponType.COFFEE.getValue(), TITLE, MESSAGE,
+                        CouponStatus.RESERVING.name()),
+                TimeResponse.of(new MeetingTime(localDateTime.toLocalDate(), localDateTime,
+                        TimeZoneType.ASIA_SEOUL.getId())));
+
+        given(couponQueryService.getCouponDetail(anyLong(), anyLong()))
+                .willReturn(couponDetailResponse);
+        ResultActions resultActions = mockMvc.perform(get("/api/coupons/1")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpectAll(
+                        status().isOk(),
+                        content().string(objectMapper.writeValueAsString(couponDetailResponse)));
+
+        resultActions.andDo(document("coupons/get-coupon",
+                getResponsePreprocessor(),
+                requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("token")
+                ),
+                responseFields(
+                        fieldWithPath("coupon.couponId").type(NUMBER).description("couponId"),
+                        fieldWithPath("coupon.sender.id").type(NUMBER).description("senderId"),
+                        fieldWithPath("coupon.sender.name").type(STRING).description("senderName"),
+                        fieldWithPath("coupon.sender.email").type(STRING).description("senderEmail"),
+                        fieldWithPath("coupon.sender.imageUrl").type(STRING).description("senderImageUrl"),
+                        fieldWithPath("coupon.receiver.id").type(NUMBER).description("receiverId"),
+                        fieldWithPath("coupon.receiver.name").type(STRING).description("receiverName"),
+                        fieldWithPath("coupon.receiver.email").type(STRING).description("receiverEmail"),
+                        fieldWithPath("coupon.receiver.imageUrl").type(STRING).description("receiverImageUrl"),
+                        fieldWithPath("coupon.content.couponType").type(STRING).description("couponType"),
+                        fieldWithPath("coupon.content.title").type(STRING).description("title"),
+                        fieldWithPath("coupon.content.message").type(STRING).description("message"),
+                        fieldWithPath("coupon.status").type(STRING).description("status"),
+                        fieldWithPath("time.meetingTime").type(STRING).description("date"),
+                        fieldWithPath("time.timeZone").type(STRING).description("timeZone")
                 )
         ));
     }

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.woowacourse.thankoo.reservation.domain;
+package com.woowacourse.thankoo.meeting.domain;
 
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.MESSAGE;
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TITLE;
@@ -20,13 +20,19 @@ import com.woowacourse.thankoo.coupon.domain.CouponContent;
 import com.woowacourse.thankoo.coupon.domain.CouponRepository;
 import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.member.domain.MemberRepository;
+import com.woowacourse.thankoo.reservation.domain.Reservation;
+import com.woowacourse.thankoo.reservation.domain.ReservationRepository;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@DisplayName("ReservationRepository 는 ")
+@DisplayName("MeetingRepository 는 ")
 @RepositoryTest
-class ReservationRepositoryTest {
+class MeetingRepositoryTest {
+
+    @Autowired
+    private MeetingRepository meetingRepository;
 
     @Autowired
     private ReservationRepository reservationRepository;
@@ -37,33 +43,26 @@ class ReservationRepositoryTest {
     @Autowired
     private CouponRepository couponRepository;
 
-    @DisplayName("예약을 조회한다.")
+    @DisplayName("쿠폰으로 만남을 조회한다.")
     @Test
-    void findWithCouponById() {
+    void findMeetingByCoupon() {
         Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
         Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
         Coupon coupon = couponRepository.save(
                 new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
-        Long reservationId = reservationRepository.save(ReservationFixture.createReservation(null, receiver, coupon))
-                .getId();
-        Reservation reservation = reservationRepository.findWithCouponById(reservationId)
-                .get();
-        assertThat(reservation.getCoupon()).isEqualTo(coupon);
-    }
-
-    @DisplayName("쿠폰으로 예약을 조회한다.")
-    @Test
-    void findReservationByCoupon() {
-        Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
-        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
-        Coupon coupon = couponRepository.save(
-                new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
-        Reservation savedReservation = reservationRepository.save(
+        Reservation reservation = reservationRepository.save(
                 ReservationFixture.createReservation(null, receiver, coupon));
+        Meeting savedMeeting = meetingRepository.save(
+                new Meeting(
+                        List.of(sender, receiver),
+                        reservation.getMeetingTime(),
+                        MeetingStatus.ON_PROGRESS,
+                        coupon)
+        );
+        Meeting foundMeeting = meetingRepository.findTopByCoupon_IdAndMeetingStatus(coupon.getId(),
+                        MeetingStatus.ON_PROGRESS)
+                .get();
 
-        Reservation foundReservation = reservationRepository.findTopByCoupon_IdAndReservationStatus(coupon.getId(),
-                ReservationStatus.WAITING).get();
-
-        assertThat(foundReservation).isEqualTo(savedReservation);
+        assertThat(foundMeeting).isEqualTo(savedMeeting);
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/domain/MemberTest.java
@@ -44,6 +44,13 @@ class MemberTest {
         assertThat(member.hasSameId(List.of(1L, 2L))).isTrue();
     }
 
+    @DisplayName("동일한 id를 판별한다.")
+    @Test
+    void isSameId() {
+        Member member = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL);
+        assertThat(member.isSameId(1L)).isTrue();
+    }
+
     @Nested
     @DisplayName("이름을 변경할 때 ")
     class UpdateNameTest {

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationRepositoryTest.java
@@ -61,7 +61,7 @@ class ReservationRepositoryTest {
         Reservation savedReservation = reservationRepository.save(
                 ReservationFixture.createReservation(null, receiver, coupon));
 
-        Reservation foundReservation = reservationRepository.findTopByCoupon_IdAndReservationStatus(coupon.getId(),
+        Reservation foundReservation = reservationRepository.findTopByCouponIdAndReservationStatus(coupon.getId(),
                 ReservationStatus.WAITING).get();
 
         assertThat(foundReservation).isEqualTo(savedReservation);


### PR DESCRIPTION
## 상세 내용
- 쿠폰 상태에 따라 응답하는 값이 다릅니다.
```java
    public TimeResponse getTimeResponse(final Long couponId, final CouponStatus couponStatus) {
        validateCouponStatus(couponStatus);
        if (couponStatus.isReserving()) {
            return TimeResponse.of(getReservation(couponId).getMeetingTime());
        }
        return TimeResponse.of(getMeeting(couponId).getMeetingTime());
    }
``` 
- TimeClient를 분리한 이유는 의존관계를 Meeting -> Coupon, Reservation -> Coupon 처럼 단방향으로 유지하도록 하기 위함입니다.
  - 따라서 테스트에서도 고민이 있었는데요.. 현재 프로덕션 코드에서는 모든 의존성을 끊었으나, 테스트에서는 reservationService를참고하고 있습니다. 의존성을 끊기 위해 TimeClient를 Mocking하는 형태도 고민했었는데요. 이 부분에 대한 여러분의 생각은 어떠신가요?

Close #160

