### PR TITLE
feat: 예약 취소 기능을 구현한다.

### DIFF
--- a/backend/src/docs/asciidoc/reservation.adoc
+++ b/backend/src/docs/asciidoc/reservation.adoc
@@ -34,3 +34,6 @@ operation::reservations/get-sent-reservations/[snippets='http-request,http-respo
 === 예약 승인
 
 operation::reservations/update-reservation-status[snippets='http-request,http-response']
+
+=== 예약 취소
+operation::reservations/cancel[snippets='http-request,http-response']

--- a/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
@@ -33,6 +33,7 @@ public enum ErrorType {
     INVALID_MEETING_TIME_ZONE(5004, "잘못된 타임존입니다."),
     INVALID_MEETING_STATUS(5005, "완료할 수 없는 상태입니다."),
 
+    FORBIDDEN(9001, "권한이 없습니다."),
     UNHANDLED_EXCEPTION(9999, "예상치 못한 예외입니다.");
 
     private final int code;

--- a/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
@@ -8,6 +8,7 @@ public enum ErrorType {
     NOT_AUTHENTICATED(1001, "인증되지 않았습니다."),
     ALREADY_AUTHENTICATED(1002, "이미 인증정보가 존재합니다."),
     INVALID_TOKEN(1003, "유효하지 않은 토큰입니다."),
+    FORBIDDEN(1004, "권한이 없습니다."),
 
     NOT_FOUND_MEMBER(2001, "존재하지 않는 회원입니다."),
     INVALID_MEMBER_NAME(2002, "올바르지 않은 이름입니다."),
@@ -33,7 +34,6 @@ public enum ErrorType {
     INVALID_MEETING_TIME_ZONE(5004, "잘못된 타임존입니다."),
     INVALID_MEETING_STATUS(5005, "완료할 수 없는 상태입니다."),
 
-    FORBIDDEN(9001, "권한이 없습니다."),
     UNHANDLED_EXCEPTION(9999, "예상치 못한 예외입니다.");
 
     private final int code;

--- a/backend/src/main/java/com/woowacourse/thankoo/common/exception/ForbiddenException.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/exception/ForbiddenException.java
@@ -1,0 +1,14 @@
+package com.woowacourse.thankoo.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ForbiddenException extends RuntimeException {
+
+    private final int code;
+
+    public ForbiddenException(final ErrorType errorType) {
+        super(errorType.getMessage());
+        this.code = errorType.getCode();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/thankoo/common/exception/GlobalControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/exception/GlobalControllerAdvice.java
@@ -26,6 +26,12 @@ public class GlobalControllerAdvice {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponse(e.getCode(), e.getMessage()));
     }
 
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ErrorResponse> forbiddenExceptionHandler(final ForbiddenException e) {
+        log.error("Forbidden Exception", e);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponse(e.getCode(), e.getMessage()));
+    }
+
     @SlackLogger
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> unHandledExceptionHandler(final Exception e) {

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/Coupon.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/Coupon.java
@@ -79,7 +79,7 @@ public class Coupon extends BaseEntity {
         return couponStatus.isReserving();
     }
 
-    public void denied() {
+    public void rollBack() {
         couponStatus = CouponStatus.NOT_USED;
     }
 

--- a/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/Meeting.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/Meeting.java
@@ -2,6 +2,7 @@ package com.woowacourse.thankoo.meeting.domain;
 
 import com.woowacourse.thankoo.common.domain.BaseEntity;
 import com.woowacourse.thankoo.common.exception.ErrorType;
+import com.woowacourse.thankoo.common.exception.ForbiddenException;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.meeting.exception.InvalidMeetingException;
 import com.woowacourse.thankoo.member.domain.Member;
@@ -98,7 +99,7 @@ public class Meeting extends BaseEntity {
 
     private void validateCompleteMember(final Member member) {
         if (!isAttendee(member)) {
-            throw new InvalidMeetingException(ErrorType.INVALID_MEETING_MEMBER);
+            throw new ForbiddenException(ErrorType.FORBIDDEN);
         }
     }
 

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/application/ReservationService.java
@@ -48,7 +48,8 @@ public class ReservationService {
                              final ReservationStatusRequest reservationStatusRequest) {
         Member foundMember = getMemberById(memberId);
         Reservation reservation = getReservationById(reservationId);
-        reservation.update(foundMember, reservationStatusRequest.getStatus(), reservedMeetingCreator);
+        ReservationStatus futureStatus = ReservationStatus.from(reservationStatusRequest.getStatus());
+        reservation.update(foundMember, futureStatus, reservedMeetingCreator);
     }
 
     public void cancel(final Long memberId,

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/application/ReservationService.java
@@ -47,9 +47,20 @@ public class ReservationService {
                              final Long reservationId,
                              final ReservationStatusRequest reservationStatusRequest) {
         Member foundMember = getMemberById(memberId);
-        Reservation foundReservation = reservationRepository.findWithCouponById(reservationId)
+        Reservation reservation = getReservationById(reservationId);
+        reservation.update(foundMember, reservationStatusRequest.getStatus(), reservedMeetingCreator);
+    }
+
+    public void cancel(final Long memberId,
+                       final Long reservationId) {
+        Member foundMember = getMemberById(memberId);
+        Reservation reservation = getReservationById(reservationId);
+        reservation.cancel(foundMember);
+    }
+
+    private Reservation getReservationById(final Long reservationId) {
+        return reservationRepository.findWithCouponById(reservationId)
                 .orElseThrow(() -> new InvalidReservationException(ErrorType.NOT_FOUND_RESERVATION));
-        foundReservation.update(foundMember, reservationStatusRequest.getStatus(), reservedMeetingCreator);
     }
 
     private Member getMemberById(final Long memberId) {

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/Reservation.java
@@ -2,6 +2,7 @@ package com.woowacourse.thankoo.reservation.domain;
 
 import com.woowacourse.thankoo.common.domain.BaseEntity;
 import com.woowacourse.thankoo.common.exception.ErrorType;
+import com.woowacourse.thankoo.common.exception.ForbiddenException;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.meeting.domain.MeetingTime;
 import com.woowacourse.thankoo.member.domain.Member;
@@ -128,7 +129,7 @@ public class Reservation extends BaseEntity {
 
     public void cancel(final Member member) {
         if (!member.isSameId(memberId)) {
-            throw new InvalidReservationException(ErrorType.CAN_NOT_CHANGE_RESERVATION_STATUS);
+            throw new ForbiddenException(ErrorType.FORBIDDEN);
         }
         if (!reservationStatus.isWaiting()) {
             throw new InvalidReservationException(ErrorType.CAN_NOT_CHANGE_RESERVATION_STATUS);

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/Reservation.java
@@ -100,7 +100,7 @@ public class Reservation extends BaseEntity {
 
         reservationStatus = updateReservationStatus;
         if (reservationStatus.isDeny()) {
-            coupon.denied();
+            coupon.rollBack();
             return;
         }
         coupon.accepted();
@@ -124,6 +124,18 @@ public class Reservation extends BaseEntity {
         if (!coupon.canAcceptReservation()) {
             throw new InvalidReservationException(ErrorType.CAN_NOT_CHANGE_RESERVATION_STATUS);
         }
+    }
+
+    public void cancel(final Member member) {
+        if (!member.isSameId(memberId)) {
+            throw new InvalidReservationException(ErrorType.CAN_NOT_CHANGE_RESERVATION_STATUS);
+        }
+        if (!reservationStatus.isWaiting()) {
+            throw new InvalidReservationException(ErrorType.CAN_NOT_CHANGE_RESERVATION_STATUS);
+        }
+
+        coupon.rollBack();
+        reservationStatus = ReservationStatus.CANCELED;
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/Reservation.java
@@ -93,13 +93,12 @@ public class Reservation extends BaseEntity {
     }
 
     public void update(final Member member,
-                       final String status,
+                       final ReservationStatus futureStatus,
                        final ReservedMeetingCreator reservedMeetingCreator) {
-        ReservationStatus updateReservationStatus = ReservationStatus.from(status);
-        validateReservation(member, updateReservationStatus);
+        validateReservation(member, futureStatus);
         validateCouponStatus();
 
-        reservationStatus = updateReservationStatus;
+        reservationStatus = futureStatus;
         if (reservationStatus.isDeny()) {
             coupon.rollBack();
             return;
@@ -108,16 +107,16 @@ public class Reservation extends BaseEntity {
         reservedMeetingCreator.create(this);
     }
 
-    private void validateReservation(final Member member, final ReservationStatus updateReservationStatus) {
-        if (isInsufficientReservationStatus(member.getId(), updateReservationStatus)) {
+    private void validateReservation(final Member member, final ReservationStatus futureStatus) {
+        if (isInsufficientReservationStatus(member.getId(), futureStatus)) {
             throw new InvalidReservationException(ErrorType.CAN_NOT_CHANGE_RESERVATION_STATUS);
         }
     }
 
     private boolean isInsufficientReservationStatus(final Long memberId,
-                                                    final ReservationStatus updateReservationStatus) {
+                                                    final ReservationStatus futureStatus) {
         return !this.reservationStatus.isWaiting()
-                || updateReservationStatus.isWaiting()
+                || futureStatus.isWaiting()
                 || !coupon.isSender(memberId);
     }
 

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/ReservationStatus.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/ReservationStatus.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 
 public enum ReservationStatus {
 
-    WAITING, DENY, ACCEPT;
+    WAITING, DENY, ACCEPT, CANCELED;
 
     public static ReservationStatus from(final String status) {
         return Arrays.stream(values())

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/presentation/ReservationController.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/presentation/ReservationController.java
@@ -51,4 +51,11 @@ public class ReservationController {
         reservationService.updateStatus(memberId, reservationId, reservationStatusRequest);
         return ResponseEntity.noContent().build();
     }
+
+    @PutMapping("/{reservationId}/cancel")
+    public ResponseEntity<Void> cancel(@AuthenticationPrincipal final Long memberId,
+                                       @PathVariable final Long reservationId) {
+        reservationService.cancel(memberId, reservationId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/acceptance/support/fixtures/ReservationRequestFixture.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/acceptance/support/fixtures/ReservationRequestFixture.java
@@ -27,4 +27,8 @@ public class ReservationRequestFixture {
     public static ExtractableResponse<Response> 예약을_승인한다(final String reservationId, final String token) {
         return putWithToken("/api/reservations/" + reservationId, token, new ReservationStatusRequest("accept"));
     }
+
+    public static ExtractableResponse<Response> 예약을_취소한다(final String reservationId, final String token) {
+        return putWithToken("/api/reservations/" + reservationId + "/cancel", token);
+    }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponTest.java
@@ -68,7 +68,7 @@ class CouponTest {
     void setCouponStatusIsNotUsed() {
         Coupon coupon = new Coupon(1L, 2L, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                 CouponStatus.NOT_USED);
-        coupon.denied();
+        coupon.rollBack();
 
         assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.NOT_USED);
     }

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/application/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/application/MeetingServiceTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.thankoo.common.annotations.ApplicationTest;
+import com.woowacourse.thankoo.common.exception.ForbiddenException;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.coupon.domain.CouponContent;
 import com.woowacourse.thankoo.coupon.domain.CouponRepository;
@@ -79,8 +80,8 @@ class MeetingServiceTest {
                     .get();
 
             assertThatThrownBy(() -> meetingService.complete(other.getId(), meeting.getId()))
-                    .isInstanceOf(InvalidMeetingException.class)
-                    .hasMessage("잘못된 미팅 참여자입니다.");
+                    .isInstanceOf(ForbiddenException.class)
+                    .hasMessage("권한이 없습니다.");
         }
 
         @DisplayName("미팅 참여자가 맞을 경우 성공한다.")

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingQueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingQueryRepositoryTest.java
@@ -84,7 +84,7 @@ class MeetingQueryRepositoryTest {
                     new Reservation(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, skrr.getId(),
                             coupon));
             reservation.reserve();
-            reservation.update(lala, "accept", reservedMeetingCreator);
+            reservation.update(lala, ReservationStatus.ACCEPT, reservedMeetingCreator);
         }
 
         List<MeetingCoupon> meetingsByMembers = meetingQueryRepository.findMeetingsByMemberId(lala.getId());

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingTest.java
@@ -19,6 +19,7 @@ import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_
 import static com.woowacourse.thankoo.common.fixtures.ReservationFixture.createReservation;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.thankoo.common.exception.ForbiddenException;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.coupon.domain.CouponContent;
 import com.woowacourse.thankoo.coupon.domain.CouponStatus;
@@ -91,8 +92,8 @@ class MeetingTest {
                     coupon);
 
             assertThatThrownBy(() -> meeting.complete(other))
-                    .isInstanceOf(InvalidMeetingException.class)
-                    .hasMessage("잘못된 미팅 참여자입니다.");
+                    .isInstanceOf(ForbiddenException.class)
+                    .hasMessage("권한이 없습니다.");
         }
 
         @DisplayName("미팅이 진행 중이 아닐 경우 예외가 발생한다.")

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/application/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/application/ReservationServiceTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.thankoo.common.annotations.ApplicationTest;
+import com.woowacourse.thankoo.common.exception.ForbiddenException;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.coupon.domain.CouponContent;
 import com.woowacourse.thankoo.coupon.domain.CouponRepository;
@@ -178,8 +179,8 @@ class ReservationServiceTest {
                     new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L)));
 
             assertThatThrownBy(() -> reservationService.cancel(sender.getId(), reservationId))
-                    .isInstanceOf(InvalidReservationException.class)
-                    .hasMessage("예약 상태를 변경할 수 없습니다.");
+                    .isInstanceOf(ForbiddenException.class)
+                    .hasMessage("권한이 없습니다.");
         }
 
         @DisplayName("예약 대기 중이 아닐경우 취소하면 실패한다.")

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/application/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/application/ReservationServiceTest.java
@@ -35,6 +35,7 @@ import com.woowacourse.thankoo.reservation.domain.ReservationStatus;
 import com.woowacourse.thankoo.reservation.exception.InvalidReservationException;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -139,5 +140,62 @@ class ReservationServiceTest {
                 () -> assertThat(foundReservation.getReservationStatus()).isEqualTo(ReservationStatus.DENY),
                 () -> assertThat(meetingRepository.findAll()).hasSize(0)
         );
+    }
+
+    @DisplayName("예약을 취소할 때 ")
+    @Nested
+    class CancelTest {
+
+        @DisplayName("예약자가 취소하면 성공한다.")
+        @Test
+        void cancel() {
+            Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+            Coupon coupon = couponRepository.save(
+                    new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+            Long reservationId = reservationService.save(receiver.getId(),
+                    new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L)));
+
+            reservationService.cancel(receiver.getId(), reservationId);
+
+            Reservation foundReservation = reservationRepository.findById(reservationId).get();
+
+            assertAll(
+                    () -> assertThat(foundReservation.getReservationStatus()).isEqualTo(ReservationStatus.CANCELED),
+                    () -> assertThat(couponRepository.findById(coupon.getId()).get().getCouponStatus()).isEqualTo(
+                            NOT_USED)
+            );
+        }
+
+        @DisplayName("예약자가 아닌 멤버가 취소하면 실패한다.")
+        @Test
+        void memberNotRequestMemberException() {
+            Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+            Coupon coupon = couponRepository.save(
+                    new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+            Long reservationId = reservationService.save(receiver.getId(),
+                    new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L)));
+
+            assertThatThrownBy(() -> reservationService.cancel(sender.getId(), reservationId))
+                    .isInstanceOf(InvalidReservationException.class)
+                    .hasMessage("예약 상태를 변경할 수 없습니다.");
+        }
+
+        @DisplayName("예약 대기 중이 아닐경우 취소하면 실패한다.")
+        @Test
+        void reservationNotWaitingException() {
+            Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+            Coupon coupon = couponRepository.save(
+                    new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+            Long reservationId = reservationService.save(receiver.getId(),
+                    new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L)));
+
+            reservationService.updateStatus(sender.getId(), reservationId, new ReservationStatusRequest("deny"));
+            assertThatThrownBy(() -> reservationService.cancel(receiver.getId(), reservationId))
+                    .isInstanceOf(InvalidReservationException.class)
+                    .hasMessage("예약 상태를 변경할 수 없습니다.");
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
@@ -241,7 +241,7 @@ class ReservationTest {
                     .hasMessage("권한이 없습니다.");
         }
 
-        @DisplayName("예약자가 아닐 경우 실패한다.")
+        @DisplayName("예약 상태가 waiting이 아닐 경우 실패한다.")
         @Test
         void reservationNotWaitingException() {
             LocalDateTime futureDate = LocalDateTime.now().plusDays(1L);

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.thankoo.common.exception.ForbiddenException;
 import com.woowacourse.thankoo.common.fake.FakeReservedMeetingCreator;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.coupon.domain.CouponContent;
@@ -236,8 +237,8 @@ class ReservationTest {
             reservation.reserve();
 
             assertThatThrownBy(() -> reservation.cancel(sender))
-                    .isInstanceOf(InvalidReservationException.class)
-                    .hasMessage("예약 상태를 변경할 수 없습니다.");
+                    .isInstanceOf(ForbiddenException.class)
+                    .hasMessage("권한이 없습니다.");
         }
 
         @DisplayName("예약자가 아닐 경우 실패한다.")

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
@@ -127,7 +127,7 @@ class ReservationTest {
 
             assertThatThrownBy(
                     () -> reservation.update(new Member(1L, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL),
-                            "accept", new FakeReservedMeetingCreator()))
+                            ReservationStatus.ACCEPT, new FakeReservedMeetingCreator()))
                     .isInstanceOf(InvalidReservationException.class)
                     .hasMessage("예약 상태를 변경할 수 없습니다.");
         }
@@ -146,7 +146,7 @@ class ReservationTest {
 
             assertThatThrownBy(
                     () -> reservation.update(new Member(1L, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL),
-                            "waiting", new FakeReservedMeetingCreator()))
+                            ReservationStatus.WAITING, new FakeReservedMeetingCreator()))
                     .isInstanceOf(InvalidReservationException.class)
                     .hasMessage("예약 상태를 변경할 수 없습니다.");
         }
@@ -165,7 +165,8 @@ class ReservationTest {
 
             assertThatThrownBy(
                     () -> reservation.update(
-                            new Member(receiverId, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL), "accept",
+                            new Member(receiverId, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL),
+                            ReservationStatus.ACCEPT,
                             new FakeReservedMeetingCreator()))
                     .isInstanceOf(InvalidReservationException.class)
                     .hasMessage("예약 상태를 변경할 수 없습니다.");
@@ -185,7 +186,8 @@ class ReservationTest {
 
             assertThatThrownBy(
                     () -> reservation.update(
-                            new Member(senderId, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL), "accept",
+                            new Member(senderId, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL),
+                            ReservationStatus.ACCEPT,
                             new FakeReservedMeetingCreator()))
                     .isInstanceOf(InvalidReservationException.class)
                     .hasMessage("예약 상태를 변경할 수 없습니다.");
@@ -206,7 +208,8 @@ class ReservationTest {
                     receiverId, coupon);
             reservation.reserve();
 
-            reservation.update(new Member(senderId, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL), "accept",
+            reservation.update(new Member(senderId, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL),
+                    ReservationStatus.ACCEPT,
                     new FakeReservedMeetingCreator());
 
             assertAll(

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
@@ -6,6 +6,9 @@ import static com.woowacourse.thankoo.common.fixtures.MemberFixture.IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -211,4 +214,51 @@ class ReservationTest {
             );
         }
     }
+
+    @DisplayName("예약을 취소할 떄 ")
+    @Nested
+    class CancelTest {
+
+        @DisplayName("예약자가 아닐 경우 실패한다.")
+        @Test
+        void memberNotOwnerException() {
+            LocalDateTime futureDate = LocalDateTime.now().plusDays(1L);
+            Member sender = new Member(1L, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL);
+            Member receiver = new Member(2L, SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL);
+
+            Coupon coupon = new Coupon(sender.getId(), receiver.getId(),
+                    new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
+                    CouponStatus.NOT_USED);
+            Reservation reservation = new Reservation(1L,
+                    new MeetingTime(futureDate.toLocalDate(), futureDate, TimeZoneType.ASIA_SEOUL.getId()),
+                    ReservationStatus.WAITING,
+                    receiver.getId(), coupon);
+            reservation.reserve();
+
+            assertThatThrownBy(() -> reservation.cancel(sender))
+                    .isInstanceOf(InvalidReservationException.class)
+                    .hasMessage("예약 상태를 변경할 수 없습니다.");
+        }
+
+        @DisplayName("예약자가 아닐 경우 실패한다.")
+        @Test
+        void reservationNotWaitingException() {
+            LocalDateTime futureDate = LocalDateTime.now().plusDays(1L);
+            Member sender = new Member(1L, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL);
+            Member receiver = new Member(2L, SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL);
+
+            Coupon coupon = new Coupon(sender.getId(), receiver.getId(),
+                    new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
+                    CouponStatus.NOT_USED);
+            Reservation reservation = new Reservation(1L,
+                    new MeetingTime(futureDate.toLocalDate(), futureDate, TimeZoneType.ASIA_SEOUL.getId()),
+                    ReservationStatus.ACCEPT,
+                    receiver.getId(), coupon);
+
+            assertThatThrownBy(() -> reservation.cancel(receiver))
+                    .isInstanceOf(InvalidReservationException.class)
+                    .hasMessage("예약 상태를 변경할 수 없습니다.");
+        }
+    }
+
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/presentation/ReservationControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/presentation/ReservationControllerTest.java
@@ -150,4 +150,24 @@ class ReservationControllerTest extends ControllerTest {
                         fieldWithPath("status").type(STRING).description("status")
                 )));
     }
+
+    @DisplayName("예약을 취소한다.")
+    @Test
+    void cancel() throws Exception {
+        given(jwtTokenProvider.getPayload(anyString()))
+                .willReturn("1");
+        doNothing().when(reservationService).cancel(anyLong(), anyLong());
+
+        ResultActions resultActions = mockMvc.perform(put("/api/reservations/1/cancel")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(
+                        status().isNoContent());
+
+        resultActions.andDo(document("reservations/cancel",
+                requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("token")
+                )));
+    }
 }


### PR DESCRIPTION
## 상세 내용
- 예약 취소 기능 구현

### Forbidden
403 에러인 Forbidden은 권한이 없음을 나타냅니다. 예약 삭제 요청할 수 없는 멤버 (예약 신청자가 아닌 경우)가 예약 삭제 요청을 하면 권한 없음 에러를 발생하기 위해 Forbidden 예외를 추가했습니다.
이에 대한 의견 주시면 감사하겠습니다.

### 도메인 로직
검증하는 방식은 아래와 같습니다.

```java
// cancel 도메인 로직
public void cancel(final Member member) {
        if (!member.isSameId(memberId)) {
            throw new ForbiddenException(ErrorType.FORBIDDEN); 
        }
        if (!reservationStatus.isWaiting()) {
            throw new InvalidReservationException(ErrorType.CAN_NOT_CHANGE_RESERVATION_STATUS);
        }

        coupon.rollBack();
        reservationStatus = ReservationStatus.CANCELED;
    }
```
도메인의 행동에 집중하기 위해 coupon은 원래 상태로 돌아간다는 의미인 `rollback`을 사용했습니다. 다른 의견 있으시면 공유 부탁드립니다.

Close #205 

