### PR TITLE
refactor: MeetingTime을 웹 요청에서 검증한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
@@ -34,7 +34,7 @@ public enum ErrorType {
     INVALID_MEETING_TIME_ZONE(5004, "잘못된 타임존입니다."),
     INVALID_MEETING_STATUS(5005, "완료할 수 없는 상태입니다."),
 
-    REQUEST_EXCEPTION(6001, "요청 에러입니다."),
+    REQUEST_EXCEPTION(6001, "http 요청 에러입니다."),
     UNHANDLED_EXCEPTION(9999, "예상치 못한 예외입니다.");
 
     private final int code;

--- a/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
@@ -34,6 +34,7 @@ public enum ErrorType {
     INVALID_MEETING_TIME_ZONE(5004, "잘못된 타임존입니다."),
     INVALID_MEETING_STATUS(5005, "완료할 수 없는 상태입니다."),
 
+    REQUEST_EXCEPTION(6001, "요청 에러입니다."),
     UNHANDLED_EXCEPTION(9999, "예상치 못한 예외입니다.");
 
     private final int code;

--- a/backend/src/main/java/com/woowacourse/thankoo/common/exception/GlobalControllerAdvice.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/exception/GlobalControllerAdvice.java
@@ -7,6 +7,7 @@ import com.woowacourse.thankoo.common.exception.dto.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -30,6 +31,12 @@ public class GlobalControllerAdvice {
     public ResponseEntity<ErrorResponse> forbiddenExceptionHandler(final ForbiddenException e) {
         log.error("Forbidden Exception", e);
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponse(e.getCode(), e.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> springValidationExceptionHandler(final MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity.badRequest().body(new ErrorResponse(ErrorType.REQUEST_EXCEPTION.getCode(), message));
     }
 
     @SlackLogger

--- a/backend/src/main/java/com/woowacourse/thankoo/common/validator/MeetingTimeRequestValidator.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/validator/MeetingTimeRequestValidator.java
@@ -1,0 +1,23 @@
+package com.woowacourse.thankoo.common.validator;
+
+import com.woowacourse.thankoo.common.validator.annotations.ValidMeetingTime;
+import com.woowacourse.thankoo.reservation.application.dto.ReservationRequest;
+import java.time.LocalDateTime;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MeetingTimeRequestValidator implements ConstraintValidator<ValidMeetingTime, ReservationRequest> {
+
+    @Override
+    public void initialize(final ValidMeetingTime constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(final ReservationRequest value, final ConstraintValidatorContext context) {
+        if (LocalDateTime.now().isAfter(value.getStartAt())) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/thankoo/common/validator/annotations/ValidMeetingTime.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/validator/annotations/ValidMeetingTime.java
@@ -1,0 +1,21 @@
+package com.woowacourse.thankoo.common.validator.annotations;
+
+import com.woowacourse.thankoo.common.validator.MeetingTimeRequestValidator;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Constraint(validatedBy = MeetingTimeRequestValidator.class)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidMeetingTime {
+
+    String message() default "예약 시간을 다시 설정해주세요.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/com/woowacourse/thankoo/common/validator/annotations/ValidMeetingTime.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/validator/annotations/ValidMeetingTime.java
@@ -13,7 +13,7 @@ import javax.validation.Payload;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidMeetingTime {
 
-    String message() default "예약 시간을 다시 설정해주세요.";
+    String message() default "예약 시간이 잘못됐습니다.";
 
     Class<?>[] groups() default {};
 

--- a/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/MeetingTime.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/MeetingTime.java
@@ -26,17 +26,10 @@ public class MeetingTime {
     private String timeZone;
 
     public MeetingTime(final LocalDate date, final LocalDateTime time, final String timeZone) {
-        validateTime(time);
         validateEqualDate(date, time);
         this.date = date;
         this.time = time;
         this.timeZone = timeZone;
-    }
-
-    private void validateTime(final LocalDateTime meetingTime) {
-        if (LocalDateTime.now().isAfter(meetingTime)) {
-            throw new InvalidReservationException(ErrorType.INVALID_RESERVATION_MEETING_TIME);
-        }
     }
 
     private void validateEqualDate(final LocalDate meetingDate, final LocalDateTime meetingTime) {

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/application/dto/ReservationRequest.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/application/dto/ReservationRequest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.thankoo.reservation.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.woowacourse.thankoo.common.validator.annotations.ValidMeetingTime;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@ValidMeetingTime
 public class ReservationRequest {
 
     private Long couponId;

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/presentation/ReservationController.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/presentation/ReservationController.java
@@ -8,6 +8,7 @@ import com.woowacourse.thankoo.reservation.application.dto.ReservationStatusRequ
 import com.woowacourse.thankoo.reservation.presentation.dto.SimpleReservationResponse;
 import java.net.URI;
 import java.util.List;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,7 +29,7 @@ public class ReservationController {
 
     @PostMapping
     public ResponseEntity<Void> reserve(@AuthenticationPrincipal final Long memberId,
-                                        @RequestBody final ReservationRequest reservationRequest) {
+                                        @RequestBody @Valid final ReservationRequest reservationRequest) {
         Long reserveId = reservationService.save(memberId, reservationRequest);
         return ResponseEntity.created(URI.create("/api/reservations/" + reserveId)).build();
     }

--- a/backend/src/test/java/com/woowacourse/thankoo/acceptance/builder/ReservationAssured.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/acceptance/builder/ReservationAssured.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.thankoo.acceptance.builder.common.RequestBuilder;
 import com.woowacourse.thankoo.acceptance.builder.common.ResponseBuilder;
+import com.woowacourse.thankoo.common.exception.dto.ErrorResponse;
 import com.woowacourse.thankoo.coupon.presentation.dto.CouponResponse;
 import com.woowacourse.thankoo.reservation.application.dto.ReservationRequest;
 import com.woowacourse.thankoo.reservation.application.dto.ReservationStatusRequest;
@@ -25,6 +26,10 @@ public class ReservationAssured {
 
     public static ReservationRequest 예약_요청(final CouponResponse couponResponse, final Long days) {
         return new ReservationRequest(couponResponse.getCouponId(), LocalDateTime.now().plusDays(days));
+    }
+
+    public static ReservationRequest 잘못된_예약_일정_요청(final CouponResponse couponResponse, final Long days) {
+        return new ReservationRequest(couponResponse.getCouponId(), LocalDateTime.now().minusDays(days));
     }
 
     public static ReservationRequestBuilder request() {
@@ -90,6 +95,11 @@ public class ReservationAssured {
                     () -> assertThat(simpleReservationResponses).isNotEmpty(),
                     () -> assertThat(simpleReservationResponses).hasSize(size)
             );
+        }
+
+        public void 예약_요청_실패됨(final int code) {
+            ErrorResponse errorResponse = body(ErrorResponse.class);
+            assertThat(errorResponse.getErrorCode()).isEqualTo(code);
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingTimeTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingTimeTest.java
@@ -12,16 +12,6 @@ import org.junit.jupiter.api.Test;
 @DisplayName("ReservationTime 은 ")
 class MeetingTimeTest {
 
-    @DisplayName("예약 시간이 오늘보다 이전인 경우 예외가 발생한다.")
-    @Test
-    void validateMeetingTime() {
-        LocalDateTime localDateTime = LocalDateTime.now().minusDays(1L);
-        assertThatThrownBy(
-                () -> new MeetingTime(localDateTime.toLocalDate(), localDateTime, TimeZoneType.ASIA_SEOUL.getId()))
-                .isInstanceOf(InvalidReservationException.class)
-                .hasMessage("유효하지 않은 일정입니다.");
-    }
-
     @DisplayName("예약 시간과 날짜가 동일하지 않을 경우 예외가 발생한다.")
     @Test
     void validateMeetingDateEquals() {

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
@@ -57,25 +57,6 @@ class ReservationTest {
                     );
         }
 
-        @DisplayName("예약 요청이 불가능한 기간이면 예외가 발생한다.")
-        @Test
-        void invalidMeetingTime() {
-            LocalDateTime futureDate = LocalDateTime.now().minusDays(1L);
-            Long receiverId = 2L;
-
-            Coupon coupon = new Coupon(1L, receiverId, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
-                    CouponStatus.NOT_USED);
-
-            assertThatThrownBy(
-                    () -> new Reservation(futureDate,
-                            TimeZoneType.ASIA_SEOUL,
-                            ReservationStatus.WAITING,
-                            receiverId,
-                            coupon))
-                    .isInstanceOf(InvalidReservationException.class)
-                    .hasMessage("유효하지 않은 일정입니다.");
-        }
-
         @DisplayName("쿠폰 수신인과 예약 요청자가 다르면 예외가 발생한다.")
         @Test
         void invalidReservationMember() {

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/presentation/ReservationControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/presentation/ReservationControllerTest.java
@@ -71,7 +71,7 @@ class ReservationControllerTest extends ControllerTest {
             ));
         }
 
-        @DisplayName("잘못된 일정이면 실패한다.")
+        @DisplayName("잘못된 일정이 실패한다.")
         @Test
         void reserveMeetingTimeFail() throws Exception {
             given(jwtTokenProvider.getPayload(anyString()))
@@ -83,7 +83,7 @@ class ReservationControllerTest extends ControllerTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andDo(print())
                     .andExpect(status().isBadRequest())
-                    .andExpect(content().string(objectMapper.writeValueAsString(new ErrorResponse(6001, "예약 시간을 다시 설정해주세요."))));
+                    .andExpect(content().string(objectMapper.writeValueAsString(new ErrorResponse(6001, "예약 시간이 잘못됐습니다."))));
         }
     }
 


### PR DESCRIPTION
## 상세 내용
```java
@Constraint(validatedBy = MeetingTimeRequestValidator.class)
@Target(ElementType.TYPE)
@Retention(RetentionPolicy.RUNTIME)
public @interface ValidMeetingTime {
```
위 애노테이션이 존재하는 클래스를 `MeetingTimeRequestValidator` 클래스로 검증합니다.

- 인수 테스트와 컨트롤러 테스트를 추가했고 도메인 테스트는 제거했습니다.

Close #221 

