### PR TITLE
refactor: 예약과 관련한 리팩터링을 진행한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/infrastructure/integrate/dto/MeetingResponse.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/infrastructure/integrate/dto/MeetingResponse.java
@@ -44,4 +44,14 @@ public class MeetingResponse {
                 .map(meetingMember -> MemberResponse.of(meetingMember.getMember()))
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public String toString() {
+        return "MeetingResponse{" +
+                "meetingId=" + meetingId +
+                ", members=" + members +
+                ", time=" + time +
+                ", status='" + status + '\'' +
+                '}';
+    }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/infrastructure/integrate/dto/ReservationResponse.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/infrastructure/integrate/dto/ReservationResponse.java
@@ -26,4 +26,13 @@ public class ReservationResponse {
                 TimeResponse.of(reservation.getTimeUnit()),
                 reservation.getReservationStatus().name());
     }
+
+    @Override
+    public String toString() {
+        return "ReservationResponse{" +
+                "reservationId=" + reservationId +
+                ", time=" + time +
+                ", status='" + status + '\'' +
+                '}';
+    }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/ReservationMeetingService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/ReservationMeetingService.java
@@ -1,10 +1,10 @@
 package com.woowacourse.thankoo.meeting.domain;
 
+import com.woowacourse.thankoo.common.domain.TimeUnit;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.member.domain.MemberRepository;
 import com.woowacourse.thankoo.reservation.application.ReservedMeetingCreator;
-import com.woowacourse.thankoo.reservation.domain.Reservation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -19,10 +19,9 @@ public class ReservationMeetingService implements ReservedMeetingCreator {
 
     @Transactional
     @Override
-    public void create(final Reservation reservation) {
-        Coupon coupon = reservation.getCoupon();
+    public void create(final Coupon coupon, final TimeUnit timeUnit) {
         List<Member> members = memberRepository.findAllById(List.of(coupon.getSenderId(), coupon.getReceiverId()));
-        Meeting meeting = new Meeting(members, reservation.getTimeUnit(), MeetingStatus.ON_PROGRESS, coupon);
+        Meeting meeting = new Meeting(members, timeUnit, MeetingStatus.ON_PROGRESS, coupon);
         meetingRepository.save(meeting);
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/member/domain/Name.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/domain/Name.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Name {
 
-    private static final int NAME_MAX_LENGTH = 20;
+    private static final int NAME_MAX_LENGTH = 5;
 
     @Column(name = "name", length = 50)
     private String value;

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/application/ReservationService.java
@@ -33,12 +33,11 @@ public class ReservationService {
                 .orElseThrow(() -> new InvalidCouponException(ErrorType.NOT_FOUND_COUPON));
         Member foundMember = getMemberById(memberId);
 
-        Reservation reservation = new Reservation(reservationRequest.getStartAt(),
+        Reservation reservation = Reservation.reserve(reservationRequest.getStartAt(),
                 TimeZoneType.ASIA_SEOUL,
                 ReservationStatus.WAITING,
                 foundMember.getId(),
                 coupon);
-        reservation.reserve();
 
         return reservationRepository.save(reservation).getId();
     }

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/application/ReservedMeetingCreator.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/application/ReservedMeetingCreator.java
@@ -1,8 +1,9 @@
 package com.woowacourse.thankoo.reservation.application;
 
-import com.woowacourse.thankoo.reservation.domain.Reservation;
+import com.woowacourse.thankoo.common.domain.TimeUnit;
+import com.woowacourse.thankoo.coupon.domain.Coupon;
 
 public interface ReservedMeetingCreator {
 
-    void create(Reservation reservation);
+    void create(Coupon coupon, TimeUnit timeUnit);
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/Reservation.java
@@ -50,11 +50,11 @@ public class Reservation extends BaseEntity {
     @JoinColumn(name = "coupon_id", nullable = false)
     private Coupon coupon;
 
-    public Reservation(final Long id,
-                       final TimeUnit timeUnit,
-                       final ReservationStatus reservationStatus,
-                       final Long memberId,
-                       final Coupon coupon) {
+    private Reservation(final Long id,
+                        final TimeUnit timeUnit,
+                        final ReservationStatus reservationStatus,
+                        final Long memberId,
+                        final Coupon coupon) {
         validateRightTime(timeUnit);
         validateReservationMember(memberId, coupon);
         validateCouponStatus(coupon);

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/Reservation.java
@@ -65,7 +65,7 @@ public class Reservation extends BaseEntity {
         this.coupon = coupon;
     }
 
-    public Reservation(final LocalDateTime meetingTime,
+    private Reservation(final LocalDateTime meetingTime,
                        final TimeZoneType timeZone,
                        final ReservationStatus reservationStatus,
                        final Long memberId,
@@ -95,7 +95,17 @@ public class Reservation extends BaseEntity {
         }
     }
 
-    public void reserve() {
+    public static Reservation reserve(final LocalDateTime meetingTime,
+                                      final TimeZoneType timeZone,
+                                      final ReservationStatus reservationStatus,
+                                      final Long memberId,
+                                      final Coupon coupon) {
+        Reservation reservation = new Reservation(meetingTime, timeZone, reservationStatus, memberId, coupon);
+        reservation.reserve();
+        return reservation;
+    }
+
+    private void reserve() {
         coupon.reserve();
     }
 

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/Reservation.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/domain/Reservation.java
@@ -1,10 +1,10 @@
 package com.woowacourse.thankoo.reservation.domain;
 
 import com.woowacourse.thankoo.common.domain.BaseEntity;
+import com.woowacourse.thankoo.common.domain.TimeUnit;
 import com.woowacourse.thankoo.common.exception.ErrorType;
 import com.woowacourse.thankoo.common.exception.ForbiddenException;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
-import com.woowacourse.thankoo.common.domain.TimeUnit;
 import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.reservation.application.ReservedMeetingCreator;
 import com.woowacourse.thankoo.reservation.exception.InvalidReservationException;
@@ -66,10 +66,10 @@ public class Reservation extends BaseEntity {
     }
 
     private Reservation(final LocalDateTime meetingTime,
-                       final TimeZoneType timeZone,
-                       final ReservationStatus reservationStatus,
-                       final Long memberId,
-                       final Coupon coupon) {
+                        final TimeZoneType timeZone,
+                        final ReservationStatus reservationStatus,
+                        final Long memberId,
+                        final Coupon coupon) {
         this(null,
                 new TimeUnit(meetingTime.toLocalDate(), meetingTime, timeZone.getId()),
                 reservationStatus,
@@ -121,7 +121,7 @@ public class Reservation extends BaseEntity {
             return;
         }
         coupon.accepted();
-        reservedMeetingCreator.create(this);
+        reservedMeetingCreator.create(coupon, timeUnit);
     }
 
     private void validateReservation(final Member member, final ReservationStatus futureStatus) {

--- a/backend/src/test/java/com/woowacourse/thankoo/common/fake/FakeReservedMeetingCreator.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/common/fake/FakeReservedMeetingCreator.java
@@ -1,13 +1,14 @@
 package com.woowacourse.thankoo.common.fake;
 
+import com.woowacourse.thankoo.common.domain.TimeUnit;
+import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.reservation.application.ReservedMeetingCreator;
-import com.woowacourse.thankoo.reservation.domain.Reservation;
 
 public class FakeReservedMeetingCreator implements ReservedMeetingCreator {
 
     @Override
-    public void create(final Reservation reservation) {
-        if (reservation == null) {
+    public void create(final Coupon coupon, final TimeUnit timeUnit) {
+        if (coupon == null || timeUnit == null) {
             throw new IllegalArgumentException();
         }
     }

--- a/backend/src/test/java/com/woowacourse/thankoo/common/fixtures/ReservationFixture.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/common/fixtures/ReservationFixture.java
@@ -1,12 +1,5 @@
 package com.woowacourse.thankoo.common.fixtures;
 
-import com.woowacourse.thankoo.coupon.domain.Coupon;
-import com.woowacourse.thankoo.common.domain.TimeUnit;
-import com.woowacourse.thankoo.member.domain.Member;
-import com.woowacourse.thankoo.reservation.domain.Reservation;
-import com.woowacourse.thankoo.reservation.domain.ReservationStatus;
-import com.woowacourse.thankoo.reservation.domain.TimeZoneType;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public class ReservationFixture {
@@ -14,22 +7,7 @@ public class ReservationFixture {
     public static final String ACCEPT = "accept";
     public static final String DENY = "deny";
 
-    /**
-     * member must have id
-     * coupon status is not used
-     *
-     * @param reservationId
-     * @param receiver
-     * @param coupon
-     * @return
-     */
-    public static Reservation createReservation(final Long reservationId, final Member receiver, final Coupon coupon) {
-        return new Reservation(reservationId,
-                new TimeUnit(LocalDate.now().plusDays(1L),
-                        LocalDateTime.now().plusDays(1L),
-                        TimeZoneType.ASIA_SEOUL.getId()),
-                ReservationStatus.WAITING,
-                receiver.getId(),
-                coupon);
+    public static LocalDateTime time(final Long plusDays) {
+        return LocalDateTime.now().plusDays(plusDays);
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/infrastructure/integrate/JpaMeetingProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/infrastructure/integrate/JpaMeetingProviderTest.java
@@ -9,7 +9,7 @@ import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
-import static com.woowacourse.thankoo.common.fixtures.ReservationFixture.createReservation;
+import static com.woowacourse.thankoo.common.fixtures.ReservationFixture.time;
 import static com.woowacourse.thankoo.coupon.domain.CouponStatus.NOT_USED;
 import static com.woowacourse.thankoo.coupon.domain.CouponType.COFFEE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +27,8 @@ import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.member.domain.MemberRepository;
 import com.woowacourse.thankoo.reservation.domain.Reservation;
 import com.woowacourse.thankoo.reservation.domain.ReservationRepository;
+import com.woowacourse.thankoo.reservation.domain.ReservationStatus;
+import com.woowacourse.thankoo.reservation.domain.TimeZoneType;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,7 +60,12 @@ class JpaMeetingProviderTest {
         Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
         Coupon coupon = couponRepository.save(
                 new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
-        Reservation reservation = reservationRepository.save(createReservation(null, receiver, coupon));
+        Reservation reservation = reservationRepository.save(
+                Reservation.reserve(time(1L),
+                        TimeZoneType.ASIA_SEOUL,
+                        ReservationStatus.WAITING,
+                        receiver.getId(),
+                        coupon));
 
         Meeting meeting = meetingRepository.save(
                 new Meeting(

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/infrastructure/integrate/JpaReservationProviderTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/infrastructure/integrate/JpaReservationProviderTest.java
@@ -9,7 +9,7 @@ import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
-import static com.woowacourse.thankoo.common.fixtures.ReservationFixture.createReservation;
+import static com.woowacourse.thankoo.common.fixtures.ReservationFixture.time;
 import static com.woowacourse.thankoo.coupon.domain.CouponStatus.NOT_USED;
 import static com.woowacourse.thankoo.coupon.domain.CouponType.COFFEE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,6 +23,8 @@ import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.member.domain.MemberRepository;
 import com.woowacourse.thankoo.reservation.domain.Reservation;
 import com.woowacourse.thankoo.reservation.domain.ReservationRepository;
+import com.woowacourse.thankoo.reservation.domain.ReservationStatus;
+import com.woowacourse.thankoo.reservation.domain.TimeZoneType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,7 +52,12 @@ class JpaReservationProviderTest {
         Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
         Coupon coupon = couponRepository.save(
                 new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
-        Reservation reservation = reservationRepository.save(createReservation(null, receiver, coupon));
+        Reservation reservation = reservationRepository.save(
+                Reservation.reserve(time(1L),
+                        TimeZoneType.ASIA_SEOUL,
+                        ReservationStatus.WAITING,
+                        receiver.getId(),
+                        coupon));
         ReservationResponse reservationResponse = jpaReservationProvider.getWaitingReservation(coupon.getId());
         assertThat(reservationResponse.getTime().getMeetingTime()).isEqualTo(
                 reservation.getTimeUnit().getTime());

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingQueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingQueryRepositoryTest.java
@@ -82,9 +82,8 @@ class MeetingQueryRepositoryTest {
 
         for (Coupon coupon : coupons) {
             Reservation reservation = reservationRepository.save(
-                    new Reservation(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, skrr.getId(),
+                    Reservation.reserve(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, skrr.getId(),
                             coupon));
-            reservation.reserve();
             reservation.update(lala, ReservationStatus.ACCEPT, reservedMeetingCreator);
         }
 

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingRepositoryTest.java
@@ -9,13 +9,13 @@ import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.ReservationFixture.time;
 import static com.woowacourse.thankoo.coupon.domain.CouponStatus.NOT_USED;
 import static com.woowacourse.thankoo.coupon.domain.CouponType.COFFEE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.thankoo.common.annotations.RepositoryTest;
-import com.woowacourse.thankoo.common.fixtures.ReservationFixture;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.coupon.domain.CouponContent;
 import com.woowacourse.thankoo.coupon.domain.CouponRepository;
@@ -23,6 +23,8 @@ import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.member.domain.MemberRepository;
 import com.woowacourse.thankoo.reservation.domain.Reservation;
 import com.woowacourse.thankoo.reservation.domain.ReservationRepository;
+import com.woowacourse.thankoo.reservation.domain.ReservationStatus;
+import com.woowacourse.thankoo.reservation.domain.TimeZoneType;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,7 +56,11 @@ class MeetingRepositoryTest {
         Coupon coupon = couponRepository.save(
                 new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
         Reservation reservation = reservationRepository.save(
-                ReservationFixture.createReservation(null, receiver, coupon));
+                Reservation.reserve(time(1L),
+                        TimeZoneType.ASIA_SEOUL,
+                        ReservationStatus.WAITING,
+                        receiver.getId(),
+                        coupon));
         Meeting savedMeeting = meetingRepository.save(
                 new Meeting(
                         List.of(sender, receiver),
@@ -79,7 +85,11 @@ class MeetingRepositoryTest {
             Coupon coupon = couponRepository.save(
                     new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
             Reservation reservation = reservationRepository.save(
-                    ReservationFixture.createReservation(null, receiver, coupon));
+                    Reservation.reserve(time(1L),
+                            TimeZoneType.ASIA_SEOUL,
+                            ReservationStatus.WAITING,
+                            receiver.getId(),
+                            coupon));
             meetingRepository.save(new Meeting(
                     List.of(sender, receiver),
                     reservation.getTimeUnit(),
@@ -106,7 +116,11 @@ class MeetingRepositoryTest {
             Coupon coupon = couponRepository.save(
                     new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
             Reservation reservation = reservationRepository.save(
-                    ReservationFixture.createReservation(null, receiver, coupon));
+                    Reservation.reserve(time(1L),
+                            TimeZoneType.ASIA_SEOUL,
+                            ReservationStatus.WAITING,
+                            receiver.getId(),
+                            coupon));
             Meeting meeting = meetingRepository.save(new Meeting(
                     List.of(sender, receiver),
                     reservation.getTimeUnit(),

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingTest.java
@@ -16,7 +16,7 @@ import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
-import static com.woowacourse.thankoo.common.fixtures.ReservationFixture.createReservation;
+import static com.woowacourse.thankoo.common.fixtures.ReservationFixture.time;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.woowacourse.thankoo.common.domain.TimeUnit;
@@ -27,6 +27,7 @@ import com.woowacourse.thankoo.coupon.domain.CouponStatus;
 import com.woowacourse.thankoo.meeting.exception.InvalidMeetingException;
 import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.reservation.domain.Reservation;
+import com.woowacourse.thankoo.reservation.domain.ReservationStatus;
 import com.woowacourse.thankoo.reservation.domain.TimeZoneType;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -45,7 +46,11 @@ class MeetingTest {
         Member lala = new Member(3L, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL);
         Coupon coupon = new Coupon(1L, huni.getId(), skrr.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
                 CouponStatus.NOT_USED);
-        Reservation reservation = createReservation(1L, skrr, coupon);
+        Reservation reservation = Reservation.reserve(time(1L),
+                TimeZoneType.ASIA_SEOUL,
+                ReservationStatus.WAITING,
+                skrr.getId(),
+                coupon);
 
         assertThatThrownBy(
                 () -> new Meeting(1L,
@@ -85,7 +90,11 @@ class MeetingTest {
         Member skrr = new Member(2L, SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL);
         Coupon coupon = new Coupon(1L, huni.getId(), skrr.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
                 CouponStatus.NOT_USED);
-        Reservation reservation = createReservation(1L, skrr, coupon);
+        Reservation reservation = Reservation.reserve(time(1L),
+                TimeZoneType.ASIA_SEOUL,
+                ReservationStatus.WAITING,
+                skrr.getId(),
+                coupon);
 
         assertThatThrownBy(
                 () -> new Meeting(1L,
@@ -109,7 +118,11 @@ class MeetingTest {
             Member other = new Member(3L, HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, IMAGE_URL);
             Coupon coupon = new Coupon(1L, huni.getId(), skrr.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
-            Reservation reservation = createReservation(1L, skrr, coupon);
+            Reservation reservation = Reservation.reserve(time(1L),
+                    TimeZoneType.ASIA_SEOUL,
+                    ReservationStatus.WAITING,
+                    skrr.getId(),
+                    coupon);
 
             Meeting meeting = new Meeting(1L, List.of(huni, skrr), reservation.getTimeUnit(),
                     MeetingStatus.ON_PROGRESS,
@@ -127,7 +140,11 @@ class MeetingTest {
             Member skrr = new Member(2L, SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL);
             Coupon coupon = new Coupon(1L, huni.getId(), skrr.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
-            Reservation reservation = createReservation(1L, skrr, coupon);
+            Reservation reservation = Reservation.reserve(time(1L),
+                    TimeZoneType.ASIA_SEOUL,
+                    ReservationStatus.WAITING,
+                    skrr.getId(),
+                    coupon);
 
             Meeting meeting = new Meeting(1L, List.of(huni, skrr), reservation.getTimeUnit(), MeetingStatus.FINISHED,
                     coupon);
@@ -144,7 +161,13 @@ class MeetingTest {
             Member skrr = new Member(2L, SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL);
             Coupon coupon = new Coupon(1L, huni.getId(), skrr.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
-            Reservation reservation = createReservation(1L, skrr, coupon);
+            Reservation reservation = Reservation.reserve(time(1L),
+                    TimeZoneType.ASIA_SEOUL,
+                    ReservationStatus.WAITING,
+                    skrr.getId(),
+                    coupon);
+
+            reservation.cancel(skrr);
 
             Meeting meeting = new Meeting(1L, List.of(huni, skrr), reservation.getTimeUnit(), MeetingStatus.FINISHED,
                     coupon);

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/ReservationMeetingQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/ReservationMeetingQueryServiceTest.java
@@ -63,7 +63,7 @@ class ReservationMeetingQueryServiceTest {
         Reservation reservation = reservationRepository.findWithCouponById(reservationId)
                 .get();
 
-        reservationMeetingService.create(reservation);
+        reservationMeetingService.create(reservation.getCoupon(), reservation.getTimeUnit());
 
         assertThat(meetingRepository.findAll()).hasSize(1);
     }

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/ReservationMeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/ReservationMeetingServiceTest.java
@@ -70,6 +70,4 @@ class ReservationMeetingServiceTest {
                 .isInstanceOf(InvalidMeetingException.class)
                 .hasMessage("유효하지 않은 일정입니다.");
     }
-
-
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/ReservationMeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/ReservationMeetingServiceTest.java
@@ -1,0 +1,75 @@
+package com.woowacourse.thankoo.meeting.domain;
+
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.MESSAGE;
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TITLE;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.IMAGE_URL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
+import static com.woowacourse.thankoo.coupon.domain.CouponStatus.NOT_USED;
+import static com.woowacourse.thankoo.coupon.domain.CouponType.COFFEE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.woowacourse.thankoo.common.annotations.ApplicationTest;
+import com.woowacourse.thankoo.common.domain.TimeUnit;
+import com.woowacourse.thankoo.coupon.domain.Coupon;
+import com.woowacourse.thankoo.coupon.domain.CouponContent;
+import com.woowacourse.thankoo.coupon.domain.CouponRepository;
+import com.woowacourse.thankoo.meeting.exception.InvalidMeetingException;
+import com.woowacourse.thankoo.member.domain.Member;
+import com.woowacourse.thankoo.member.domain.MemberRepository;
+import com.woowacourse.thankoo.reservation.application.ReservedMeetingCreator;
+import com.woowacourse.thankoo.reservation.domain.Reservation;
+import com.woowacourse.thankoo.reservation.domain.ReservationRepository;
+import com.woowacourse.thankoo.reservation.domain.ReservationStatus;
+import com.woowacourse.thankoo.reservation.domain.TimeZoneType;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("ReservationMeetingService 는 ")
+@ApplicationTest
+class ReservationMeetingServiceTest {
+
+    @Autowired
+    private ReservedMeetingCreator reservedMeetingCreator;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private CouponRepository couponRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("예약을 승인 시 현재 이전일 경우 실패한다.")
+    @Test
+    void acceptTimeFailed() {
+        Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+        Coupon coupon = couponRepository.save(
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+
+        Reservation reservation = reservationRepository.save(Reservation.reserve(LocalDateTime.now().plusDays(1L),
+                TimeZoneType.ASIA_SEOUL,
+                ReservationStatus.WAITING,
+                receiver.getId(),
+                coupon));
+
+        LocalDateTime failDate = LocalDateTime.now().minusDays(1L);
+        assertThatThrownBy(() ->
+                reservedMeetingCreator.create(reservation.getCoupon(), new TimeUnit(failDate.toLocalDate(),
+                        failDate,
+                        TimeZoneType.ASIA_SEOUL.getId()))
+        )
+                .isInstanceOf(InvalidMeetingException.class)
+                .hasMessage("유효하지 않은 일정입니다.");
+    }
+
+
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/domain/MemberTest.java
@@ -21,7 +21,7 @@ class MemberTest {
 
     @DisplayName("올바르지 않은 이름으로 생성하면 예외가 발생한다.")
     @ParameterizedTest
-    @ValueSource(strings = {" ", "abcdefghijkabcdefghijk1"})
+    @ValueSource(strings = {" ", "abcdef"})
     void createWithInvalidNameException(String name) {
         assertThatThrownBy(() -> new Member(name, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL))
                 .isInstanceOf(InvalidMemberException.class)

--- a/backend/src/test/java/com/woowacourse/thankoo/member/domain/NameTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/domain/NameTest.java
@@ -12,7 +12,7 @@ class NameTest {
 
     @DisplayName("올바르지 않은 이름이 들어올 경우 예외가 발생한다.")
     @ParameterizedTest
-    @ValueSource(strings = {" ", "abcdefghijkabcdefghijk1"})
+    @ValueSource(strings = {" ", "abcdef"})
     void createNameException(String value) {
         assertThatThrownBy(() -> new Name(value))
                 .isInstanceOf(InvalidMemberException.class)

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/application/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/application/ReservationServiceTest.java
@@ -26,7 +26,6 @@ import com.woowacourse.thankoo.coupon.domain.CouponRepository;
 import com.woowacourse.thankoo.coupon.domain.CouponStatus;
 import com.woowacourse.thankoo.coupon.exception.InvalidCouponException;
 import com.woowacourse.thankoo.meeting.domain.MeetingRepository;
-import com.woowacourse.thankoo.meeting.exception.InvalidMeetingException;
 import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.member.domain.MemberRepository;
 import com.woowacourse.thankoo.reservation.application.dto.ReservationRequest;
@@ -117,26 +116,6 @@ class ReservationServiceTest {
                 new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L))))
                 .isInstanceOf(InvalidReservationException.class)
                 .hasMessage("예약을 요청할 수 없는 회원입니다.");
-    }
-
-    @DisplayName("예약을 승인 시 현재 이전일 경우 실패한다.")
-    @Test
-    void acceptTimeFailed() throws InterruptedException {
-        Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
-        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
-        Coupon coupon = couponRepository.save(
-                new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
-        Long reservationId = reservationService.save(receiver.getId(),
-                new ReservationRequest(coupon.getId(), LocalDateTime.now().plusSeconds(1L)));
-
-        Thread.sleep(1000);
-        assertThatThrownBy(() ->
-                reservationService.updateStatus(
-                        sender.getId(),
-                        reservationId,
-                        new ReservationStatusRequest("accept")))
-                .isInstanceOf(InvalidMeetingException.class)
-                .hasMessage("유효하지 않은 일정입니다.");
     }
 
     @DisplayName("예약을 승인한다.")

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationQueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationQueryRepositoryTest.java
@@ -67,13 +67,13 @@ class ReservationQueryRepositoryTest {
 
         LocalDateTime meetingDate = LocalDateTime.now().plusDays(1L);
         reservationRepository.save(
-                new Reservation(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, skrr.getId(),
+                Reservation.reserve(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, skrr.getId(),
                         coupon1));
         reservationRepository.save(
-                new Reservation(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, skrr.getId(),
+                Reservation.reserve(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, skrr.getId(),
                         coupon2));
         reservationRepository.save(
-                new Reservation(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, lala.getId(),
+                Reservation.reserve(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, lala.getId(),
                         coupon3));
 
         List<ReservationCoupon> receivedReservations = reservationQueryRepository.findReceivedReservations(lala.getId(),
@@ -100,13 +100,13 @@ class ReservationQueryRepositoryTest {
 
         LocalDateTime meetingDate = LocalDateTime.now().plusDays(1L);
         reservationRepository.save(
-                new Reservation(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, skrr.getId(),
+                Reservation.reserve(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, skrr.getId(),
                         coupon1));
         reservationRepository.save(
-                new Reservation(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, skrr.getId(),
+                Reservation.reserve(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, skrr.getId(),
                         coupon2));
         reservationRepository.save(
-                new Reservation(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, lala.getId(),
+                Reservation.reserve(meetingDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING, lala.getId(),
                         coupon3));
 
         List<ReservationCoupon> sentReservations = reservationQueryRepository.findSentReservations(lala.getId(),

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationRepositoryTest.java
@@ -9,12 +9,12 @@ import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.ReservationFixture.time;
 import static com.woowacourse.thankoo.coupon.domain.CouponStatus.NOT_USED;
 import static com.woowacourse.thankoo.coupon.domain.CouponType.COFFEE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.thankoo.common.annotations.RepositoryTest;
-import com.woowacourse.thankoo.common.fixtures.ReservationFixture;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.coupon.domain.CouponContent;
 import com.woowacourse.thankoo.coupon.domain.CouponRepository;
@@ -44,8 +44,11 @@ class ReservationRepositoryTest {
         Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
         Coupon coupon = couponRepository.save(
                 new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
-        Long reservationId = reservationRepository.save(ReservationFixture.createReservation(null, receiver, coupon))
-                .getId();
+        Long reservationId = reservationRepository.save(Reservation.reserve(time(1L),
+                TimeZoneType.ASIA_SEOUL,
+                ReservationStatus.WAITING,
+                receiver.getId(),
+                coupon)).getId();
         Reservation reservation = reservationRepository.findWithCouponById(reservationId)
                 .get();
         assertThat(reservation.getCoupon()).isEqualTo(coupon);
@@ -59,7 +62,11 @@ class ReservationRepositoryTest {
         Coupon coupon = couponRepository.save(
                 new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
         Reservation savedReservation = reservationRepository.save(
-                ReservationFixture.createReservation(null, receiver, coupon));
+                Reservation.reserve(time(1L),
+                        TimeZoneType.ASIA_SEOUL,
+                        ReservationStatus.WAITING,
+                        receiver.getId(),
+                        coupon));
 
         Reservation foundReservation = reservationRepository.findTopByCouponIdAndReservationStatus(coupon.getId(),
                 ReservationStatus.WAITING).get();

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
@@ -14,13 +14,13 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.thankoo.common.domain.TimeUnit;
 import com.woowacourse.thankoo.common.exception.ForbiddenException;
 import com.woowacourse.thankoo.common.fake.FakeReservedMeetingCreator;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.coupon.domain.CouponContent;
 import com.woowacourse.thankoo.coupon.domain.CouponStatus;
 import com.woowacourse.thankoo.coupon.domain.CouponType;
-import com.woowacourse.thankoo.common.domain.TimeUnit;
 import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.reservation.exception.InvalidReservationException;
 import java.time.LocalDateTime;
@@ -117,9 +117,11 @@ class ReservationTest {
 
             Coupon coupon = new Coupon(1L, receiverId, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
-            Reservation reservation = new Reservation(futureDate, TimeZoneType.ASIA_SEOUL, reservationStatus,
-                    receiverId, coupon);
-            reservation.reserve();
+            Reservation reservation = Reservation.reserve(futureDate,
+                    TimeZoneType.ASIA_SEOUL,
+                    reservationStatus,
+                    receiverId,
+                    coupon);
 
             assertThatThrownBy(
                     () -> reservation.update(new Member(1L, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL),
@@ -136,9 +138,11 @@ class ReservationTest {
 
             Coupon coupon = new Coupon(1L, receiverId, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
-            Reservation reservation = new Reservation(futureDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING,
-                    receiverId, coupon);
-            reservation.reserve();
+            Reservation reservation = Reservation.reserve(futureDate,
+                    TimeZoneType.ASIA_SEOUL,
+                    ReservationStatus.WAITING,
+                    receiverId,
+                    coupon);
 
             assertThatThrownBy(
                     () -> reservation.update(new Member(1L, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL),
@@ -155,9 +159,9 @@ class ReservationTest {
 
             Coupon coupon = new Coupon(1L, receiverId, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
-            Reservation reservation = new Reservation(futureDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING,
+            Reservation reservation = Reservation.reserve(futureDate, TimeZoneType.ASIA_SEOUL,
+                    ReservationStatus.WAITING,
                     receiverId, coupon);
-            reservation.reserve();
 
             assertThatThrownBy(
                     () -> reservation.update(
@@ -198,11 +202,11 @@ class ReservationTest {
 
             Coupon coupon = new Coupon(senderId, receiverId, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
-            Reservation reservation = new Reservation(1L,
-                    new TimeUnit(futureDate.toLocalDate(), futureDate, TimeZoneType.ASIA_SEOUL.getId()),
+            Reservation reservation = Reservation.reserve(futureDate,
+                    TimeZoneType.ASIA_SEOUL,
                     ReservationStatus.WAITING,
-                    receiverId, coupon);
-            reservation.reserve();
+                    receiverId,
+                    coupon);
 
             reservation.update(new Member(senderId, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL),
                     ReservationStatus.ACCEPT,
@@ -229,11 +233,11 @@ class ReservationTest {
             Coupon coupon = new Coupon(sender.getId(), receiver.getId(),
                     new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
-            Reservation reservation = new Reservation(1L,
-                    new TimeUnit(futureDate.toLocalDate(), futureDate, TimeZoneType.ASIA_SEOUL.getId()),
+            Reservation reservation = Reservation.reserve(futureDate,
+                    TimeZoneType.ASIA_SEOUL,
                     ReservationStatus.WAITING,
-                    receiver.getId(), coupon);
-            reservation.reserve();
+                    receiver.getId(),
+                    coupon);
 
             assertThatThrownBy(() -> reservation.cancel(sender))
                     .isInstanceOf(ForbiddenException.class)

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
@@ -47,14 +47,17 @@ class ReservationTest {
             Coupon coupon = new Coupon(1L, receiverId, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
 
-            assertThatNoException()
-                    .isThrownBy(
-                            () -> Reservation.reserve(futureDate,
-                                    TimeZoneType.ASIA_SEOUL,
-                                    ReservationStatus.WAITING,
-                                    receiverId,
-                                    coupon)
-                    );
+            assertAll(
+                    () -> assertThatNoException()
+                            .isThrownBy(
+                                    () -> Reservation.reserve(futureDate,
+                                            TimeZoneType.ASIA_SEOUL,
+                                            ReservationStatus.WAITING,
+                                            receiverId,
+                                            coupon)
+                            ),
+                    () -> assertThat(coupon.getCouponStatus()).isEqualTo(CouponStatus.RESERVING)
+            );
         }
 
         @DisplayName("시간이 현재 이전이면 예외가 발생한다.")

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
@@ -2,6 +2,12 @@ package com.woowacourse.thankoo.reservation.domain;
 
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.MESSAGE;
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TITLE;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_SOCIAL_ID;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_NAME;
@@ -14,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.thankoo.common.domain.TimeUnit;
 import com.woowacourse.thankoo.common.exception.ForbiddenException;
 import com.woowacourse.thankoo.common.fake.FakeReservedMeetingCreator;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
@@ -179,21 +184,17 @@ class ReservationTest {
         @Test
         void updateCouponStatusException() {
             LocalDateTime futureDate = LocalDateTime.now().plusDays(1L);
-            Long receiverId = 2L;
-            Long senderId = 1L;
-
-            Coupon coupon = new Coupon(senderId, receiverId, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
+            Member huni = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL);
+            Member hoho = new Member(2L, HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, IMAGE_URL);
+            Coupon coupon = new Coupon(huni.getId(), hoho.getId(), new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
-            Reservation reservation = new Reservation(1L,
-                    new TimeUnit(futureDate.toLocalDate(),
-                            futureDate,
-                            TimeZoneType.ASIA_SEOUL.getId()),
-                    ReservationStatus.WAITING,
-                    receiverId, coupon);
+            Reservation reservation = Reservation.reserve(futureDate, TimeZoneType.ASIA_SEOUL,
+                    ReservationStatus.WAITING, hoho.getId(), coupon);
+            reservation.cancel(hoho);
 
             assertThatThrownBy(
                     () -> reservation.update(
-                            new Member(senderId, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL),
+                            new Member(huni.getId(), LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL),
                             ReservationStatus.ACCEPT,
                             new FakeReservedMeetingCreator()))
                     .isInstanceOf(InvalidReservationException.class)
@@ -261,9 +262,7 @@ class ReservationTest {
             Coupon coupon = new Coupon(sender.getId(), receiver.getId(),
                     new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
-            Reservation reservation = new Reservation(1L,
-                    new TimeUnit(futureDate.toLocalDate(), futureDate, TimeZoneType.ASIA_SEOUL.getId()),
-                    ReservationStatus.ACCEPT,
+            Reservation reservation = Reservation.reserve(futureDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.ACCEPT,
                     receiver.getId(), coupon);
 
             assertThatThrownBy(() -> reservation.cancel(receiver))
@@ -271,5 +270,4 @@ class ReservationTest {
                     .hasMessage("예약 상태를 변경할 수 없습니다.");
         }
     }
-
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/domain/ReservationTest.java
@@ -49,7 +49,7 @@ class ReservationTest {
 
             assertThatNoException()
                     .isThrownBy(
-                            () -> new Reservation(futureDate,
+                            () -> Reservation.reserve(futureDate,
                                     TimeZoneType.ASIA_SEOUL,
                                     ReservationStatus.WAITING,
                                     receiverId,
@@ -66,7 +66,7 @@ class ReservationTest {
             Coupon coupon = new Coupon(1L, receiverId, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
 
-            assertThatThrownBy(() -> new Reservation(futureDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING,
+            assertThatThrownBy(() -> Reservation.reserve(futureDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING,
                     receiverId, coupon))
                     .isInstanceOf(InvalidReservationException.class)
                     .hasMessage("유효하지 않은 일정입니다.");
@@ -81,7 +81,7 @@ class ReservationTest {
             Coupon coupon = new Coupon(1L, receiverId, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
 
-            assertThatThrownBy(() -> new Reservation(futureDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING,
+            assertThatThrownBy(() -> Reservation.reserve(futureDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING,
                     receiverId + 1, coupon))
                     .isInstanceOf(InvalidReservationException.class)
                     .hasMessage("예약을 요청할 수 없는 회원입니다.");
@@ -96,7 +96,7 @@ class ReservationTest {
 
             Coupon coupon = new Coupon(1L, receiverId, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                     couponStatus);
-            assertThatThrownBy(() -> new Reservation(futureDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING,
+            assertThatThrownBy(() -> Reservation.reserve(futureDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING,
                     receiverId, coupon))
                     .isInstanceOf(InvalidReservationException.class)
                     .hasMessage("예약 요청이 불가능한 쿠폰입니다.");
@@ -181,7 +181,11 @@ class ReservationTest {
 
             Coupon coupon = new Coupon(senderId, receiverId, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
                     CouponStatus.NOT_USED);
-            Reservation reservation = new Reservation(futureDate, TimeZoneType.ASIA_SEOUL, ReservationStatus.WAITING,
+            Reservation reservation = new Reservation(1L,
+                    new TimeUnit(futureDate.toLocalDate(),
+                            futureDate,
+                            TimeZoneType.ASIA_SEOUL.getId()),
+                    ReservationStatus.WAITING,
                     receiverId, coupon);
 
             assertThatThrownBy(


### PR DESCRIPTION
## 상세 내용
- Reservation 생성
이제부터 Reservation을 최초로 생성할 때는 `Reservation.reserve(~~)` 를 사용해주세요.
```java
    public static Reservation reserve(final LocalDateTime meetingTime,
                                      final TimeZoneType timeZone,
                                      final ReservationStatus reservationStatus,
                                      final Long memberId,
                                      final Coupon coupon) {
        Reservation reservation = new Reservation(meetingTime, timeZone, reservationStatus, memberId, coupon);
        reservation.reserve();
        return reservation;
    }

    private void reserve() {
        coupon.reserve();
    }
```

- ReservationMeetingCreator가 더이상 Reservation 객체를 알지 않아도 되도록 수정했습니다. 더이상 예약과 미팅의 관계는 존재하지 않습니다. 따라서 이름에 대한 변경도 필요해보이긴 하네요. 추천해주세용 (안 변경해도 되구 ㅎ)

Close #258 

