### PR TITLE
refactor: 알람 관련 기능을 리팩터링한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/thankoo/alarm/exception/InvalidAlarmException.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/alarm/exception/InvalidAlarmException.java
@@ -1,0 +1,11 @@
+package com.woowacourse.thankoo.alarm.exception;
+
+import com.woowacourse.thankoo.common.exception.BadRequestException;
+import com.woowacourse.thankoo.common.exception.ErrorType;
+
+public class InvalidAlarmException extends BadRequestException {
+
+    public InvalidAlarmException(final ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepository.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepository.java
@@ -1,9 +1,12 @@
 package com.woowacourse.thankoo.alarm.infrastructure;
 
+import com.woowacourse.thankoo.alarm.exception.InvalidAlarmException;
 import com.woowacourse.thankoo.common.exception.ErrorType;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 public class InMemorySlackUserRepository {
 
@@ -13,7 +16,7 @@ public class InMemorySlackUserRepository {
     public String findUserToken(final String email) {
         String userToken = store.computeIfAbsent(email, slackClient::getUserToken);
         if (userToken == null) {
-            throw new RuntimeException(ErrorType.NOT_FOUND_SLACK_USER.getMessage());
+            throw new InvalidAlarmException(ErrorType.NOT_FOUND_SLACK_USER);
         }
         return userToken;
     }

--- a/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepository.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepository.java
@@ -4,9 +4,7 @@ import com.woowacourse.thankoo.alarm.exception.InvalidAlarmException;
 import com.woowacourse.thankoo.common.exception.ErrorType;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
-@Slf4j
 @RequiredArgsConstructor
 public class InMemorySlackUserRepository {
 

--- a/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepository.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepository.java
@@ -1,5 +1,6 @@
 package com.woowacourse.thankoo.alarm.infrastructure;
 
+import com.woowacourse.thankoo.common.exception.ErrorType;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 
@@ -10,6 +11,10 @@ public class InMemorySlackUserRepository {
     private final SlackClient slackClient;
 
     public String findUserId(final String email) {
-        return store.computeIfAbsent(email, slackClient::getUserToken);
+        String userId = store.computeIfAbsent(email, slackClient::getUserToken);
+        if (userId == null) {
+            throw new RuntimeException(ErrorType.NOT_FOUND_SLACK_USER.getMessage());
+        }
+        return userId;
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepository.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepository.java
@@ -10,11 +10,11 @@ public class InMemorySlackUserRepository {
     private final Map<String, String> store;
     private final SlackClient slackClient;
 
-    public String findUserId(final String email) {
-        String userId = store.computeIfAbsent(email, slackClient::getUserToken);
-        if (userId == null) {
+    public String findUserToken(final String email) {
+        String userToken = store.computeIfAbsent(email, slackClient::getUserToken);
+        if (userToken == null) {
             throw new RuntimeException(ErrorType.NOT_FOUND_SLACK_USER.getMessage());
         }
-        return userId;
+        return userToken;
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/SlackAlarmSender.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/SlackAlarmSender.java
@@ -17,7 +17,7 @@ public class SlackAlarmSender implements AlarmSender {
     @Override
     public void send(final String email, final AlarmMessage alarmMessage) {
         try {
-            String slackUserId = slackUserRepository.findUserId(email);
+            String slackUserId = slackUserRepository.findUserToken(email);
             slackClient.sendMessage(slackUserId, alarmMessage);
         } catch (Exception e) {
             log.warn("알람 전송 실패 {}", email, e);

--- a/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/SlackAlarmSender.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/SlackAlarmSender.java
@@ -17,8 +17,8 @@ public class SlackAlarmSender implements AlarmSender {
     @Override
     public void send(final String email, final AlarmMessage alarmMessage) {
         try {
-            String slackUserId = slackUserRepository.findUserToken(email);
-            slackClient.sendMessage(slackUserId, alarmMessage);
+            String slackUserToken = slackUserRepository.findUserToken(email);
+            slackClient.sendMessage(slackUserToken, alarmMessage);
         } catch (Exception e) {
             log.warn("알람 전송 실패 {}", email, e);
         }

--- a/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/SlackClient.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/SlackClient.java
@@ -46,7 +46,7 @@ public class SlackClient {
     public String getUserToken(final String email) {
         SlackUsersResponse slackUsers = getUsers();
         SlackUserResponse slackUser = getUser(email, slackUsers);
-        return slackUser.getId();
+        return slackUser.getUserToken();
     }
 
     public void sendMessage(final String channel, final AlarmMessage message) {

--- a/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/SlackClient.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/SlackClient.java
@@ -1,6 +1,7 @@
 package com.woowacourse.thankoo.alarm.infrastructure;
 
 import com.woowacourse.thankoo.alarm.AlarmMessage;
+import com.woowacourse.thankoo.alarm.exception.InvalidAlarmException;
 import com.woowacourse.thankoo.alarm.infrastructure.dto.SlackMessageRequest;
 import com.woowacourse.thankoo.alarm.infrastructure.dto.SlackUserResponse;
 import com.woowacourse.thankoo.alarm.infrastructure.dto.SlackUsersResponse;
@@ -40,7 +41,7 @@ public class SlackClient {
                 .stream()
                 .filter(userResponse -> email.equals(userResponse.getProfile().getEmail()))
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException(ErrorType.NOT_FOUND_SLACK_USER.getMessage()));
+                .orElseThrow(() -> new InvalidAlarmException(ErrorType.NOT_FOUND_SLACK_USER));
     }
 
     public String getUserToken(final String email) {

--- a/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/SlackUserMapper.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/SlackUserMapper.java
@@ -19,6 +19,6 @@ public class SlackUserMapper {
                 .filter(slackUserResponse -> Objects.nonNull(slackUserResponse.getProfile().getEmail()))
                 .collect(Collectors.toConcurrentMap(
                         slackUserResponse -> slackUserResponse.getProfile().getEmail(),
-                        SlackUserResponse::getId));
+                        SlackUserResponse::getUserToken));
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/dto/SlackUserResponse.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/alarm/infrastructure/dto/SlackUserResponse.java
@@ -1,5 +1,6 @@
 package com.woowacourse.thankoo.alarm.infrastructure.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,11 +9,12 @@ import lombok.NoArgsConstructor;
 @Getter
 public class SlackUserResponse {
 
-    private String id;
+    @JsonProperty("id")
+    private String userToken;
     private Profile profile;
 
-    public SlackUserResponse(final String id, final Profile profile) {
-        this.id = id;
+    public SlackUserResponse(final String userToken, final Profile profile) {
+        this.userToken = userToken;
         this.profile = profile;
     }
 

--- a/backend/src/main/java/com/woowacourse/thankoo/alarm/support/AlarmManager.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/alarm/support/AlarmManager.java
@@ -1,5 +1,6 @@
 package com.woowacourse.thankoo.alarm.support;
 
+import com.woowacourse.thankoo.alarm.exception.InvalidAlarmException;
 import com.woowacourse.thankoo.common.exception.ErrorType;
 
 public class AlarmManager {
@@ -9,7 +10,7 @@ public class AlarmManager {
     public static AlarmMessageRequest getResources() {
         AlarmMessageRequest alarmMessageEvent = resources.get();
         if (alarmMessageEvent == null) {
-            throw new RuntimeException(ErrorType.NOT_FOUND_ALARM_REQUEST.getMessage());
+            throw new InvalidAlarmException(ErrorType.NOT_FOUND_ALARM_REQUEST);
         }
         return alarmMessageEvent;
     }

--- a/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
@@ -37,8 +37,9 @@ public enum ErrorType {
 
     REQUEST_EXCEPTION(6001, "http 요청 에러입니다."),
 
-    NOT_FOUND_SLACK_USER(9001, "알람이 불가능한 이메일입니다. 관리자에게 문의주세요."),
-    NOT_FOUND_ALARM_REQUEST(9002, "전송하려는 알람이 존재하지 않습니다."),
+    NOT_FOUND_SLACK_USER(7001, "알람이 불가능한 이메일입니다. 관리자에게 문의주세요."),
+    NOT_FOUND_ALARM_REQUEST(7002, "전송하려는 알람이 존재하지 않습니다."),
+
     UNHANDLED_EXCEPTION(9999, "예상치 못한 예외입니다.");
 
     private final int code;

--- a/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
@@ -37,7 +37,7 @@ public enum ErrorType {
 
     REQUEST_EXCEPTION(6001, "http 요청 에러입니다."),
 
-    NOT_FOUND_SLACK_USER(7001, "알람이 불가능한 이메일입니다. 관리자에게 문의주세요."),
+    NOT_FOUND_SLACK_USER(7001, "알람이 불가능한 이메일입니다."),
     NOT_FOUND_ALARM_REQUEST(7002, "전송하려는 알람이 존재하지 않습니다."),
 
     UNHANDLED_EXCEPTION(9999, "예상치 못한 예외입니다.");

--- a/backend/src/main/java/com/woowacourse/thankoo/common/schedule/MeetingScheduleTask.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/schedule/MeetingScheduleTask.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -16,7 +15,6 @@ public class MeetingScheduleTask {
     private final MeetingService meetingService;
 
     @Scheduled(cron = "0 0 2 * * *")
-    @Transactional
     public void executeCompleteMeeting() {
         meetingService.complete(LocalDate.now().minusDays(DAY));
     }

--- a/backend/src/main/java/com/woowacourse/thankoo/common/schedule/MeetingScheduleTask.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/schedule/MeetingScheduleTask.java
@@ -23,6 +23,6 @@ public class MeetingScheduleTask {
 
     @Scheduled(cron = "0 0 9 * * *")
     public void executeMeetingMessage() {
-        meetingService.sendMessageTodayMeetingMembers();
+        meetingService.sendMessageTodayMeetingMembers(LocalDate.now());
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/common/schedule/MeetingScheduleTask.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/schedule/MeetingScheduleTask.java
@@ -1,18 +1,7 @@
 package com.woowacourse.thankoo.common.schedule;
 
-import static com.woowacourse.thankoo.meeting.domain.MeetingStatus.ON_PROGRESS;
-
-import com.woowacourse.thankoo.alarm.support.Alarm;
-import com.woowacourse.thankoo.coupon.domain.Coupon;
-import com.woowacourse.thankoo.coupon.domain.CouponRepository;
-import com.woowacourse.thankoo.coupon.domain.CouponStatus;
-import com.woowacourse.thankoo.coupon.domain.Coupons;
 import com.woowacourse.thankoo.meeting.application.MeetingService;
-import com.woowacourse.thankoo.meeting.domain.MeetingRepository;
-import com.woowacourse.thankoo.meeting.domain.MeetingStatus;
-import com.woowacourse.thankoo.meeting.domain.Meetings;
 import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -25,21 +14,13 @@ public class MeetingScheduleTask {
     public static final Long DAY = 1L;
 
     private final MeetingService meetingService;
-    private final MeetingRepository meetingRepository;
-    private final CouponRepository couponRepository;
 
     @Scheduled(cron = "0 0 2 * * *")
     @Transactional
     public void executeCompleteMeeting() {
-        Meetings meetings = new Meetings(meetingRepository.findAllByMeetingStatusAndTimeUnit_Date(
-                ON_PROGRESS, LocalDate.now().minusDays(DAY)));
-        Coupons coupons = new Coupons(meetings.getCoupons());
-
-        meetingRepository.updateMeetingStatus(MeetingStatus.FINISHED, meetings.getMeetingIds());
-        couponRepository.updateCouponStatus(CouponStatus.USED, coupons.getCouponIds());
+        meetingService.complete(LocalDate.now().minusDays(DAY));
     }
 
-    @Alarm
     @Scheduled(cron = "0 0 9 * * *")
     public void executeMeetingMessage() {
         meetingService.sendMessageTodayMeetingMembers();

--- a/backend/src/main/java/com/woowacourse/thankoo/common/schedule/MeetingScheduleTask.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/schedule/MeetingScheduleTask.java
@@ -2,19 +2,17 @@ package com.woowacourse.thankoo.common.schedule;
 
 import static com.woowacourse.thankoo.meeting.domain.MeetingStatus.ON_PROGRESS;
 
-import com.woowacourse.thankoo.alarm.AlarmMessage;
-import com.woowacourse.thankoo.alarm.support.AlarmMessageRequest;
 import com.woowacourse.thankoo.alarm.support.Alarm;
-import com.woowacourse.thankoo.alarm.support.AlarmManager;
+import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.coupon.domain.CouponRepository;
 import com.woowacourse.thankoo.coupon.domain.CouponStatus;
-import com.woowacourse.thankoo.meeting.domain.Meeting;
+import com.woowacourse.thankoo.coupon.domain.Coupons;
+import com.woowacourse.thankoo.meeting.application.MeetingService;
 import com.woowacourse.thankoo.meeting.domain.MeetingRepository;
 import com.woowacourse.thankoo.meeting.domain.MeetingStatus;
+import com.woowacourse.thankoo.meeting.domain.Meetings;
 import java.time.LocalDate;
-import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -26,49 +24,24 @@ public class MeetingScheduleTask {
 
     public static final Long DAY = 1L;
 
+    private final MeetingService meetingService;
     private final MeetingRepository meetingRepository;
     private final CouponRepository couponRepository;
 
     @Scheduled(cron = "0 0 2 * * *")
     @Transactional
     public void executeCompleteMeeting() {
-        List<Meeting> meetings = meetingRepository.findAllByMeetingStatusAndTimeUnit_Date(
-                ON_PROGRESS, LocalDate.now().minusDays(DAY));
+        Meetings meetings = new Meetings(meetingRepository.findAllByMeetingStatusAndTimeUnit_Date(
+                ON_PROGRESS, LocalDate.now().minusDays(DAY)));
+        Coupons coupons = new Coupons(meetings.getCoupons());
 
-        List<Long> meetingIds = getMeetingIds(meetings);
-        List<Long> couponIds = getCouponIds(meetings);
-
-        meetingRepository.updateMeetingStatus(MeetingStatus.FINISHED, meetingIds);
-        couponRepository.updateCouponStatus(CouponStatus.USED, couponIds);
-    }
-
-    private List<Long> getMeetingIds(final List<Meeting> meetings) {
-        return meetings.stream()
-                .map(Meeting::getId)
-                .collect(Collectors.toList());
-    }
-
-    private List<Long> getCouponIds(final List<Meeting> meetings) {
-        return meetings.stream()
-                .map(meeting -> meeting.getCoupon().getId())
-                .collect(Collectors.toList());
+        meetingRepository.updateMeetingStatus(MeetingStatus.FINISHED, meetings.getMeetingIds());
+        couponRepository.updateCouponStatus(CouponStatus.USED, coupons.getCouponIds());
     }
 
     @Alarm
     @Scheduled(cron = "0 0 9 * * *")
     public void executeMeetingMessage() {
-        List<Meeting> meetings = meetingRepository.findAllByTimeUnit_Date(LocalDate.now());
-        List<String> emails = getEmails(meetings);
-        AlarmManager.setResources(new AlarmMessageRequest(emails, AlarmMessage.MEETING));
-        AlarmManager.clear();
-    }
-
-    private List<String> getEmails(final List<Meeting> meetings) {
-        return meetings.stream()
-                .map(meeting -> meeting.getMeetingMembers().getMeetingMembers())
-                .flatMap(Collection::stream)
-                .map(meetingMember -> meetingMember.getMember().getEmail().getValue())
-                .distinct()
-                .collect(Collectors.toList());
+        meetingService.sendMessageTodayMeetingMembers();
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/application/CouponService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/application/CouponService.java
@@ -6,8 +6,8 @@ import com.woowacourse.thankoo.alarm.support.AlarmManager;
 import com.woowacourse.thankoo.alarm.support.AlarmMessageRequest;
 import com.woowacourse.thankoo.common.exception.ErrorType;
 import com.woowacourse.thankoo.coupon.application.dto.CouponRequest;
-import com.woowacourse.thankoo.coupon.domain.Coupon;
 import com.woowacourse.thankoo.coupon.domain.CouponRepository;
+import com.woowacourse.thankoo.coupon.domain.Coupons;
 import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.member.domain.MemberRepository;
 import com.woowacourse.thankoo.member.exception.InvalidMemberException;
@@ -28,11 +28,8 @@ public class CouponService {
     @Alarm
     public void saveAll(final Long senderId, final CouponRequest couponRequest) {
         validateMember(senderId, couponRequest.getReceiverIds());
-        List<Coupon> coupons = couponRepository.saveAll(couponRequest.toEntities(senderId));
-        List<Long> receiverIds = coupons.stream()
-                .map(Coupon::getReceiverId)
-                .collect(Collectors.toList());
-        sendMessage(memberRepository.findByIdIn(receiverIds));
+        Coupons coupons = new Coupons(couponRepository.saveAll(couponRequest.toEntities(senderId)));
+        sendMessage(memberRepository.findByIdIn(coupons.getReceiverIds()));
     }
 
     private void validateMember(final Long senderId, final List<Long> receiverIds) {

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/Coupons.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/Coupons.java
@@ -1,0 +1,17 @@
+package com.woowacourse.thankoo.coupon.domain;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Coupons {
+
+    private final List<Coupon> coupons;
+
+    public Coupons(final List<Coupon> coupons) {
+        this.coupons = List.copyOf(coupons);
+    }
+
+    public List<Long> getReceiverIds() {
+        return coupons.stream().map(Coupon::getReceiverId).collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/Coupons.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/Coupons.java
@@ -11,7 +11,15 @@ public class Coupons {
         this.coupons = List.copyOf(coupons);
     }
 
+    public List<Long> getCouponIds() {
+        return coupons.stream()
+                .map(Coupon::getId)
+                .collect(Collectors.toList());
+    }
+
     public List<Long> getReceiverIds() {
-        return coupons.stream().map(Coupon::getReceiverId).collect(Collectors.toList());
+        return coupons.stream()
+                .map(Coupon::getReceiverId)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/Coupons.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/Coupons.java
@@ -5,20 +5,20 @@ import java.util.stream.Collectors;
 
 public class Coupons {
 
-    private final List<Coupon> coupons;
+    private final List<Coupon> values;
 
-    public Coupons(final List<Coupon> coupons) {
-        this.coupons = List.copyOf(coupons);
+    public Coupons(final List<Coupon> values) {
+        this.values = List.copyOf(values);
     }
 
     public List<Long> getCouponIds() {
-        return coupons.stream()
+        return values.stream()
                 .map(Coupon::getId)
                 .collect(Collectors.toList());
     }
 
     public List<Long> getReceiverIds() {
-        return coupons.stream()
+        return values.stream()
                 .map(Coupon::getReceiverId)
                 .collect(Collectors.toList());
     }

--- a/backend/src/main/java/com/woowacourse/thankoo/meeting/application/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/meeting/application/MeetingService.java
@@ -59,9 +59,11 @@ public class MeetingService {
     }
 
     @Alarm
-    public void sendMessageTodayMeetingMembers() {
-        Meetings meetings = new Meetings(meetingRepository.findAllByTimeUnit_Date(LocalDate.now()));
+    public void sendMessageTodayMeetingMembers(LocalDate date) {
+        Meetings meetings = new Meetings(meetingRepository.findAllByTimeUnit_Date(date));
         Members members = new Members(meetings.getMembers());
-        AlarmManager.setResources(new AlarmMessageRequest(members.getEmails(), AlarmMessage.MEETING));
+        if (!members.isEmpty()) {
+            AlarmManager.setResources(new AlarmMessageRequest(members.getEmails(), AlarmMessage.MEETING));
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/meeting/application/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/meeting/application/MeetingService.java
@@ -1,12 +1,18 @@
 package com.woowacourse.thankoo.meeting.application;
 
+import com.woowacourse.thankoo.alarm.AlarmMessage;
+import com.woowacourse.thankoo.alarm.support.AlarmManager;
+import com.woowacourse.thankoo.alarm.support.AlarmMessageRequest;
 import com.woowacourse.thankoo.common.exception.ErrorType;
 import com.woowacourse.thankoo.meeting.domain.Meeting;
 import com.woowacourse.thankoo.meeting.domain.MeetingRepository;
+import com.woowacourse.thankoo.meeting.domain.Meetings;
 import com.woowacourse.thankoo.meeting.exception.InvalidMeetingException;
 import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.member.domain.MemberRepository;
+import com.woowacourse.thankoo.member.domain.Members;
 import com.woowacourse.thankoo.member.exception.InvalidMemberException;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,5 +40,11 @@ public class MeetingService {
     private Member getMemberById(final Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new InvalidMemberException(ErrorType.NOT_FOUND_MEMBER));
+    }
+
+    public void sendMessageTodayMeetingMembers() {
+        Meetings meetings = new Meetings(meetingRepository.findAllByTimeUnit_Date(LocalDate.now()));
+        Members members = new Members(meetings.getMembers());
+        AlarmManager.setResources(new AlarmMessageRequest(members.getEmails(), AlarmMessage.MEETING));
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/Meetings.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/Meetings.java
@@ -10,26 +10,26 @@ import lombok.Getter;
 @Getter
 public class Meetings {
 
-    private final List<Meeting> meetings;
+    private final List<Meeting> values;
 
-    public Meetings(final List<Meeting> meetings) {
-        this.meetings = meetings;
+    public Meetings(final List<Meeting> values) {
+        this.values = values;
     }
 
     public List<Long> getMeetingIds() {
-        return meetings.stream()
+        return values.stream()
                 .map(Meeting::getId)
                 .collect(Collectors.toList());
     }
 
     public List<Coupon> getCoupons() {
-        return meetings.stream()
+        return values.stream()
                 .map(Meeting::getCoupon)
                 .collect(Collectors.toList());
     }
 
     public List<Member> getMembers() {
-        return meetings.stream()
+        return values.stream()
                 .map(meeting -> meeting.getMeetingMembers().getMeetingMembers())
                 .flatMap(Collection::stream)
                 .map(MeetingMember::getMember)

--- a/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/Meetings.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/Meetings.java
@@ -1,0 +1,38 @@
+package com.woowacourse.thankoo.meeting.domain;
+
+import com.woowacourse.thankoo.coupon.domain.Coupon;
+import com.woowacourse.thankoo.member.domain.Member;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public class Meetings {
+
+    private final List<Meeting> meetings;
+
+    public Meetings(final List<Meeting> meetings) {
+        this.meetings = meetings;
+    }
+
+    public List<Long> getMeetingIds() {
+        return meetings.stream()
+                .map(Meeting::getId)
+                .collect(Collectors.toList());
+    }
+
+    public List<Coupon> getCoupons() {
+        return meetings.stream()
+                .map(Meeting::getCoupon)
+                .collect(Collectors.toList());
+    }
+
+    public List<Member> getMembers() {
+        return meetings.stream()
+                .map(meeting -> meeting.getMeetingMembers().getMeetingMembers())
+                .flatMap(Collection::stream)
+                .map(MeetingMember::getMember)
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/thankoo/member/domain/Members.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/domain/Members.java
@@ -5,19 +5,19 @@ import java.util.stream.Collectors;
 
 public class Members {
 
-    private final List<Member> members;
+    private final List<Member> values;
 
-    public Members(final List<Member> members) {
-        this.members = List.copyOf(members);
+    public Members(final List<Member> values) {
+        this.values = List.copyOf(values);
     }
 
     public List<String> getEmails() {
-        return members.stream()
+        return values.stream()
                 .map(member -> member.getEmail().getValue())
                 .collect(Collectors.toList());
     }
 
     public boolean isEmpty() {
-        return members.isEmpty();
+        return values.isEmpty();
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/member/domain/Members.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/domain/Members.java
@@ -16,4 +16,8 @@ public class Members {
                 .map(member -> member.getEmail().getValue())
                 .collect(Collectors.toList());
     }
+
+    public boolean isEmpty() {
+        return members.isEmpty();
+    }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/member/domain/Members.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/domain/Members.java
@@ -1,0 +1,19 @@
+package com.woowacourse.thankoo.member.domain;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Members {
+
+    private final List<Member> members;
+
+    public Members(final List<Member> members) {
+        this.members = List.copyOf(members);
+    }
+
+    public List<String> getEmails() {
+        return members.stream()
+                .map(member -> member.getEmail().getValue())
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepositoryTest.java
@@ -35,7 +35,7 @@ class InMemorySlackUserRepositoryTest {
         store.put(SKRR_EMAIL, "UN7830401");
         InMemorySlackUserRepository repository = new InMemorySlackUserRepository(store, client);
 
-        String token = repository.findUserId(SKRR_EMAIL);
+        String token = repository.findUserToken(SKRR_EMAIL);
 
         verify(client, never()).getUserToken(SKRR_EMAIL);
         assertThat(token).isEqualTo("UN7830401");
@@ -52,7 +52,7 @@ class InMemorySlackUserRepositoryTest {
 
         when(client.getUserToken(SKRR_EMAIL)).thenReturn("UN7830401");
 
-        String token = repository.findUserId(SKRR_EMAIL);
+        String token = repository.findUserToken(SKRR_EMAIL);
 
         verify(client, times(1)).getUserToken(SKRR_EMAIL);
         assertThat(token).isEqualTo("UN7830401");
@@ -69,7 +69,7 @@ class InMemorySlackUserRepositoryTest {
 
         when(client.getUserToken(SKRR_EMAIL)).thenReturn(null);
 
-        assertThatThrownBy(() -> repository.findUserId(SKRR_EMAIL))
+        assertThatThrownBy(() -> repository.findUserToken(SKRR_EMAIL))
                 .hasMessage("알람이 불가능한 이메일입니다. 관리자에게 문의주세요.")
                 .isInstanceOf(RuntimeException.class);
         verify(client, times(1)).getUserToken(SKRR_EMAIL);

--- a/backend/src/test/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepositoryTest.java
@@ -1,0 +1,77 @@
+package com.woowacourse.thankoo.alarm.infrastructure;
+
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InMemorySlackUserRepositoryTest {
+
+    @Mock
+    private SlackClient client;
+
+    @Test
+    @DisplayName("저장소에 토큰이 있는 경우 클라이언트를 호출하지 않고 토큰을 조회한다.")
+    void findUserTokenInStore() {
+        Map<String, String> store = new ConcurrentHashMap<>();
+        store.put(HOHO_EMAIL, "UN1203OFJ12");
+        store.put(HUNI_EMAIL, "UN3403OFJ12");
+        store.put(LALA_EMAIL, "UN5603OFJ12");
+        store.put(SKRR_EMAIL, "UN7830401");
+        InMemorySlackUserRepository repository = new InMemorySlackUserRepository(store, client);
+
+        String token = repository.findUserId(SKRR_EMAIL);
+
+        verify(client, never()).getUserToken(SKRR_EMAIL);
+        assertThat(token).isEqualTo("UN7830401");
+    }
+
+    @Test
+    @DisplayName("저장소에 토큰이 없는 경우 클라이언트를 호출하여 토큰을 조회한다.")
+    void findUserTokenInClient() {
+        Map<String, String> store = new ConcurrentHashMap<>();
+        store.put(HOHO_EMAIL, "UN1203OFJ12");
+        store.put(HUNI_EMAIL, "UN3403OFJ12");
+        store.put(LALA_EMAIL, "UN5603OFJ12");
+        InMemorySlackUserRepository repository = new InMemorySlackUserRepository(store, client);
+
+        when(client.getUserToken(SKRR_EMAIL)).thenReturn("UN7830401");
+
+        String token = repository.findUserId(SKRR_EMAIL);
+
+        verify(client, times(1)).getUserToken(SKRR_EMAIL);
+        assertThat(token).isEqualTo("UN7830401");
+    }
+
+    @Test
+    @DisplayName("클라이언트를 호출하여 토큰을 조회했을 때 반환값이 null인 경우 예외를 발생한다.")
+    void findUserTokenInClientIsNull() {
+        Map<String, String> store = new ConcurrentHashMap<>();
+        store.put(HOHO_EMAIL, "UN1203OFJ12");
+        store.put(HUNI_EMAIL, "UN3403OFJ12");
+        store.put(LALA_EMAIL, "UN5603OFJ12");
+        InMemorySlackUserRepository repository = new InMemorySlackUserRepository(store, client);
+
+        when(client.getUserToken(SKRR_EMAIL)).thenReturn(null);
+
+        assertThatThrownBy(() -> repository.findUserId(SKRR_EMAIL))
+                .hasMessage("알람이 불가능한 이메일입니다. 관리자에게 문의주세요.")
+                .isInstanceOf(RuntimeException.class);
+        verify(client, times(1)).getUserToken(SKRR_EMAIL);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/alarm/infrastructure/InMemorySlackUserRepositoryTest.java
@@ -1,8 +1,10 @@
 package com.woowacourse.thankoo.alarm.infrastructure;
 
-import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_EMAIL;
-import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
-import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
+import static com.woowacourse.thankoo.alarm.infrastructure.SlackUserFixture.HOHO;
+import static com.woowacourse.thankoo.alarm.infrastructure.SlackUserFixture.HUNI;
+import static com.woowacourse.thankoo.alarm.infrastructure.SlackUserFixture.LALA;
+import static com.woowacourse.thankoo.alarm.infrastructure.SlackUserFixture.SKRR;
+import static com.woowacourse.thankoo.alarm.infrastructure.SlackUserFixture.SKRR_USER_TOKEN;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -22,56 +24,57 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class InMemorySlackUserRepositoryTest {
 
+    private static final int EMAIL = 0;
+    private static final int USER_TOKEN = 1;
+
     @Mock
     private SlackClient client;
 
     @Test
     @DisplayName("저장소에 토큰이 있는 경우 클라이언트를 호출하지 않고 토큰을 조회한다.")
     void findUserTokenInStore() {
-        Map<String, String> store = new ConcurrentHashMap<>();
-        store.put(HOHO_EMAIL, "UN1203OFJ12");
-        store.put(HUNI_EMAIL, "UN3403OFJ12");
-        store.put(LALA_EMAIL, "UN5603OFJ12");
-        store.put(SKRR_EMAIL, "UN7830401");
+        Map<String, String> store = givenStore(HOHO, HUNI, LALA, SKRR);
         InMemorySlackUserRepository repository = new InMemorySlackUserRepository(store, client);
 
         String token = repository.findUserToken(SKRR_EMAIL);
 
         verify(client, never()).getUserToken(SKRR_EMAIL);
-        assertThat(token).isEqualTo("UN7830401");
+        assertThat(token).isEqualTo(SKRR_USER_TOKEN);
     }
 
     @Test
     @DisplayName("저장소에 토큰이 없는 경우 클라이언트를 호출하여 토큰을 조회한다.")
     void findUserTokenInClient() {
-        Map<String, String> store = new ConcurrentHashMap<>();
-        store.put(HOHO_EMAIL, "UN1203OFJ12");
-        store.put(HUNI_EMAIL, "UN3403OFJ12");
-        store.put(LALA_EMAIL, "UN5603OFJ12");
+        Map<String, String> store = givenStore(HOHO, HUNI, LALA);
         InMemorySlackUserRepository repository = new InMemorySlackUserRepository(store, client);
 
-        when(client.getUserToken(SKRR_EMAIL)).thenReturn("UN7830401");
+        when(client.getUserToken(SKRR_EMAIL)).thenReturn(SKRR_USER_TOKEN);
 
         String token = repository.findUserToken(SKRR_EMAIL);
 
         verify(client, times(1)).getUserToken(SKRR_EMAIL);
-        assertThat(token).isEqualTo("UN7830401");
+        assertThat(token).isEqualTo(SKRR_USER_TOKEN);
     }
 
     @Test
     @DisplayName("클라이언트를 호출하여 토큰을 조회했을 때 반환값이 null인 경우 예외를 발생한다.")
     void findUserTokenInClientIsNull() {
-        Map<String, String> store = new ConcurrentHashMap<>();
-        store.put(HOHO_EMAIL, "UN1203OFJ12");
-        store.put(HUNI_EMAIL, "UN3403OFJ12");
-        store.put(LALA_EMAIL, "UN5603OFJ12");
+        Map<String, String> store = givenStore(HOHO, HUNI, LALA);
         InMemorySlackUserRepository repository = new InMemorySlackUserRepository(store, client);
 
         when(client.getUserToken(SKRR_EMAIL)).thenReturn(null);
 
         assertThatThrownBy(() -> repository.findUserToken(SKRR_EMAIL))
-                .hasMessage("알람이 불가능한 이메일입니다. 관리자에게 문의주세요.")
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("알람이 불가능한 이메일입니다.");
         verify(client, times(1)).getUserToken(SKRR_EMAIL);
+    }
+
+    private Map<String, String> givenStore(String[]... users) {
+        Map<String, String> store = new ConcurrentHashMap<>();
+        for (String[] user : users) {
+            store.put(user[EMAIL], user[USER_TOKEN]);
+        }
+        return store;
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/alarm/infrastructure/SlackUserFixture.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/alarm/infrastructure/SlackUserFixture.java
@@ -1,0 +1,19 @@
+package com.woowacourse.thankoo.alarm.infrastructure;
+
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
+
+public class SlackUserFixture {
+
+    public static final String HOHO_USER_TOKEN = "UN1203OFJ12";
+    public static final String HUNI_USER_TOKEN = "UN340F3MS14";
+    public static final String LALA_USER_TOKEN = "UN5603FBA51";
+    public static final String SKRR_USER_TOKEN = "UN7803GJ41D";
+
+    public static final String[] HOHO = {HOHO_EMAIL, HOHO_USER_TOKEN};
+    public static final String[] HUNI = {HUNI_EMAIL, HUNI_USER_TOKEN};
+    public static final String[] LALA = {LALA_EMAIL, LALA_USER_TOKEN};
+    public static final String[] SKRR = {SKRR_EMAIL, SKRR_USER_TOKEN};
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/common/annotations/ApplicationTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/common/annotations/ApplicationTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.thankoo.common.annotations;
 
+import com.woowacourse.thankoo.common.support.AlarmThreadClearExtension;
 import com.woowacourse.thankoo.common.support.DataClearExtension;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -12,6 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@ExtendWith(DataClearExtension.class)
+@ExtendWith({DataClearExtension.class, AlarmThreadClearExtension.class})
 public @interface ApplicationTest {
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/common/support/AlarmThreadClearExtension.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/common/support/AlarmThreadClearExtension.java
@@ -1,0 +1,13 @@
+package com.woowacourse.thankoo.common.support;
+
+import com.woowacourse.thankoo.alarm.support.AlarmManager;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class AlarmThreadClearExtension implements AfterEachCallback {
+
+    @Override
+    public void afterEach(final ExtensionContext context) {
+        AlarmManager.clear();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponsTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponsTest.java
@@ -1,0 +1,28 @@
+package com.woowacourse.thankoo.coupon.domain;
+
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.MESSAGE;
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TITLE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Coupons 는 ")
+class CouponsTest {
+
+    @Test
+    @DisplayName("쿠폰들에서 받은 회원의 id를 가져온다.")
+    void getReceiverIds() {
+        List<Coupon> coupons = new ArrayList<>();
+        for (long id = 0; id < 3; id++) {
+            coupons.add(new Coupon(id, id + 1, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
+                    CouponStatus.NOT_USED));
+        }
+        Coupons result = new Coupons(coupons);
+        List<Long> receiverIds = result.getReceiverIds();
+
+        assertThat(receiverIds).containsExactly(1L, 2L, 3L);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponsTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponsTest.java
@@ -13,6 +13,20 @@ import org.junit.jupiter.api.Test;
 class CouponsTest {
 
     @Test
+    @DisplayName("쿠폰들에서 쿠폰의 id를 가져온다.")
+    void getCouponIds() {
+        List<Coupon> coupons = new ArrayList<>();
+        for (long id = 0; id < 3; id++) {
+            coupons.add(new Coupon(id + 1L, id, id, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
+                    CouponStatus.NOT_USED));
+        }
+        Coupons result = new Coupons(coupons);
+        List<Long> couponIds = result.getCouponIds();
+
+        assertThat(couponIds).containsExactly(1L, 2L, 3L);
+    }
+
+    @Test
     @DisplayName("쿠폰들에서 받은 회원의 id를 가져온다.")
     void getReceiverIds() {
         List<Coupon> coupons = new ArrayList<>();

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponsTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponsTest.java
@@ -15,13 +15,8 @@ class CouponsTest {
     @Test
     @DisplayName("쿠폰들에서 쿠폰의 id를 가져온다.")
     void getCouponIds() {
-        List<Coupon> coupons = new ArrayList<>();
-        for (long id = 0; id < 3; id++) {
-            coupons.add(new Coupon(id + 1L, id, id, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
-                    CouponStatus.NOT_USED));
-        }
-        Coupons result = new Coupons(coupons);
-        List<Long> couponIds = result.getCouponIds();
+        Coupons coupons = givenCoupons();
+        List<Long> couponIds = coupons.getCouponIds();
 
         assertThat(couponIds).containsExactly(1L, 2L, 3L);
     }
@@ -29,14 +24,18 @@ class CouponsTest {
     @Test
     @DisplayName("쿠폰들에서 받은 회원의 id를 가져온다.")
     void getReceiverIds() {
-        List<Coupon> coupons = new ArrayList<>();
-        for (long id = 0; id < 3; id++) {
-            coupons.add(new Coupon(id, id + 1, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
-                    CouponStatus.NOT_USED));
-        }
-        Coupons result = new Coupons(coupons);
-        List<Long> receiverIds = result.getReceiverIds();
+        Coupons coupons = givenCoupons();
+        List<Long> receiverIds = coupons.getReceiverIds();
 
         assertThat(receiverIds).containsExactly(1L, 2L, 3L);
+    }
+
+    private Coupons givenCoupons() {
+        List<Coupon> coupons = new ArrayList<>();
+        for (long id = 0; id < 3; id++) {
+            coupons.add(new Coupon(id + 1, id + 1, id + 1, new CouponContent(CouponType.COFFEE, TITLE, MESSAGE),
+                    CouponStatus.NOT_USED));
+        }
+        return new Coupons(coupons);
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/application/MeetingServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/application/MeetingServiceTest.java
@@ -5,6 +5,7 @@ import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TITLE;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_NAME;
@@ -18,6 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.thankoo.alarm.AlarmMessage;
+import com.woowacourse.thankoo.alarm.exception.InvalidAlarmException;
+import com.woowacourse.thankoo.alarm.support.AlarmManager;
+import com.woowacourse.thankoo.alarm.support.AlarmMessageRequest;
 import com.woowacourse.thankoo.common.annotations.ApplicationTest;
 import com.woowacourse.thankoo.common.exception.ForbiddenException;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
@@ -32,6 +37,7 @@ import com.woowacourse.thankoo.member.domain.MemberRepository;
 import com.woowacourse.thankoo.reservation.application.ReservationService;
 import com.woowacourse.thankoo.reservation.application.dto.ReservationRequest;
 import com.woowacourse.thankoo.reservation.application.dto.ReservationStatusRequest;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -108,5 +114,37 @@ class MeetingServiceTest {
                     () -> assertThat(foundCoupon.getCouponStatus()).isEqualTo(CouponStatus.USED)
             );
         }
+    }
+
+    @Test
+    @DisplayName("해당 일자에 미팅이 존재하면 알람을 전송한다.")
+    void sendMessageTodayMeetingMembers() {
+        Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+
+        Coupon coupon = couponRepository.save(
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+        Long reservationId = reservationService.save(receiver.getId(),
+                new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L)));
+        reservationService.updateStatus(sender.getId(), reservationId, new ReservationStatusRequest("accept"));
+
+        meetingService.sendMessageTodayMeetingMembers(LocalDate.now().plusDays(1L));
+
+        AlarmMessageRequest request = AlarmManager.getResources();
+
+        assertAll(
+                () -> assertThat(request.getEmails()).containsExactly(LALA_EMAIL, SKRR_EMAIL),
+                () -> assertThat(request.getAlarmMessage()).isEqualTo(AlarmMessage.MEETING)
+        );
+    }
+
+    @Test
+    @DisplayName("해당 일자에 미팅이 존재하지 않으면 알람을 전송하지 않는다.")
+    void sendMessageTodayMeetingMembersIsEmpty() {
+        meetingService.sendMessageTodayMeetingMembers(LocalDate.now());
+
+        assertThatThrownBy(AlarmManager::getResources)
+                .hasMessage("전송하려는 알람이 존재하지 않습니다.")
+                .isInstanceOf(InvalidAlarmException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingsTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingsTest.java
@@ -1,0 +1,121 @@
+package com.woowacourse.thankoo.meeting.domain;
+
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.MESSAGE;
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TITLE;
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TYPE;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.IMAGE_URL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.ReservationFixture.time;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.thankoo.coupon.domain.Coupon;
+import com.woowacourse.thankoo.coupon.domain.CouponContent;
+import com.woowacourse.thankoo.coupon.domain.CouponStatus;
+import com.woowacourse.thankoo.member.domain.Member;
+import com.woowacourse.thankoo.reservation.domain.Reservation;
+import com.woowacourse.thankoo.reservation.domain.ReservationStatus;
+import com.woowacourse.thankoo.reservation.domain.TimeZoneType;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Meetings 는 ")
+class MeetingsTest {
+
+    @DisplayName("모든 미팅의 id를 조회한다.")
+    @Test
+    void getMeetingIds() {
+        Member huni = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL);
+        Member skrr = new Member(2L, SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL);
+
+        List<Meeting> meetings = new ArrayList<>();
+        for (int id = 0; id < 3; id++) {
+            Coupon coupon = new Coupon(1L, huni.getId(), skrr.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                    CouponStatus.NOT_USED);
+
+            Reservation reservation = Reservation.reserve(time(1L),
+                    TimeZoneType.ASIA_SEOUL,
+                    ReservationStatus.WAITING,
+                    skrr.getId(),
+                    coupon);
+
+            meetings.add(new Meeting(id + 1L,
+                    List.of(huni, skrr),
+                    reservation.getTimeUnit(),
+                    MeetingStatus.ON_PROGRESS,
+                    coupon));
+        }
+        Meetings result = new Meetings(meetings);
+        List<Long> meetingIds = result.getMeetingIds();
+
+        assertThat(meetingIds).contains(1L, 2L, 3L);
+    }
+
+    @DisplayName("모든 미팅의 쿠폰들을 조회한다.")
+    @Test
+    void getCoupons() {
+        Member huni = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL);
+        Member skrr = new Member(2L, SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL);
+
+        List<Meeting> meetings = new ArrayList<>();
+        for (int id = 0; id < 3; id++) {
+            Coupon coupon = new Coupon(1L, huni.getId(), skrr.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                    CouponStatus.NOT_USED);
+
+            Reservation reservation = Reservation.reserve(time(1L),
+                    TimeZoneType.ASIA_SEOUL,
+                    ReservationStatus.WAITING,
+                    skrr.getId(),
+                    coupon);
+
+            meetings.add(new Meeting(id + 1L,
+                    List.of(huni, skrr),
+                    reservation.getTimeUnit(),
+                    MeetingStatus.ON_PROGRESS,
+                    coupon));
+        }
+
+        Meetings result = new Meetings(meetings);
+
+        assertThat(result.getCoupons()).hasSize(3);
+    }
+
+    @DisplayName("모든 미팅에 참여한 회원들을 모두 조회한다.")
+    @Test
+    void getMembers() {
+        Member huni = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL);
+        Member skrr = new Member(2L, SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL);
+
+        List<Meeting> meetings = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            Coupon coupon = new Coupon(1L, huni.getId(), skrr.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                    CouponStatus.NOT_USED);
+
+            Reservation reservation = Reservation.reserve(time(1L),
+                    TimeZoneType.ASIA_SEOUL,
+                    ReservationStatus.WAITING,
+                    skrr.getId(),
+                    coupon);
+
+            meetings.add(new Meeting(1L,
+                    List.of(huni, skrr),
+                    reservation.getTimeUnit(),
+                    MeetingStatus.ON_PROGRESS,
+                    coupon));
+        }
+        Meetings result = new Meetings(meetings);
+        List<Member> members = result.getMembers();
+
+        assertAll(
+                () -> assertThat(members).hasSize(6),
+                () -> assertThat(members).contains(huni, skrr)
+        );
+    }
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/member/domain/MembersTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/domain/MembersTest.java
@@ -1,0 +1,37 @@
+package com.woowacourse.thankoo.member.domain;
+
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.IMAGE_URL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Members 는 ")
+class MembersTest {
+
+    @DisplayName("회원들의 이메일을 조회한다.")
+    @Test
+    void getEmails() {
+        Members members = new Members(List.of(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL),
+                new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL),
+                new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL),
+                new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, IMAGE_URL)));
+
+        List<String> emails = members.getEmails();
+
+        assertThat(emails).containsExactly(HUNI_EMAIL, LALA_EMAIL, SKRR_EMAIL, HOHO_EMAIL);
+    }
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/application/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/application/ReservationServiceTest.java
@@ -204,7 +204,6 @@ class ReservationServiceTest {
         );
     }
 
-
     @DisplayName("예약을 승인되면 알람을 전송한다.")
     @Test
     void sendMessageThenUpdateStatusDeny() {

--- a/backend/src/test/java/com/woowacourse/thankoo/reservation/application/ReservationServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/reservation/application/ReservationServiceTest.java
@@ -18,6 +18,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.woowacourse.thankoo.alarm.AlarmMessage;
+import com.woowacourse.thankoo.alarm.support.AlarmManager;
+import com.woowacourse.thankoo.alarm.support.AlarmMessageRequest;
 import com.woowacourse.thankoo.common.annotations.ApplicationTest;
 import com.woowacourse.thankoo.common.exception.ForbiddenException;
 import com.woowacourse.thankoo.coupon.domain.Coupon;
@@ -59,63 +62,86 @@ class ReservationServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    @DisplayName("예약을 생성한다.")
-    @Test
-    void save() {
-        Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
-        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
-        Coupon coupon = couponRepository.save(
-                new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
-        Long reservationId = reservationService.save(receiver.getId(),
-                new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L)));
-        Coupon foundCoupon = couponRepository.findById(coupon.getId()).get();
+    @DisplayName("예약을 생성할 때 ")
+    @Nested
+    class SaveTest {
 
-        assertAll(
-                () -> assertThat(reservationId).isNotNull(),
-                () -> assertThat(foundCoupon.getCouponStatus()).isEqualTo(CouponStatus.RESERVING)
-        );
-    }
+        @DisplayName("정상적으로 예약을 생성한다.")
+        @Test
+        void save() {
+            Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+            Coupon coupon = couponRepository.save(
+                    new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+            Long reservationId = reservationService.save(receiver.getId(),
+                    new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L)));
+            Coupon foundCoupon = couponRepository.findById(coupon.getId()).get();
 
-    @DisplayName("예약시 현재 이전일 경우 실패한다.")
-    @Test
-    void saveTimeFailed() {
-        Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
-        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
-        Coupon coupon = couponRepository.save(
-                new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+            assertAll(
+                    () -> assertThat(reservationId).isNotNull(),
+                    () -> assertThat(foundCoupon.getCouponStatus()).isEqualTo(CouponStatus.RESERVING)
+            );
+        }
 
-        assertThatThrownBy(() ->
-                reservationService.save(receiver.getId(),
-                        new ReservationRequest(coupon.getId(), LocalDateTime.now().minusSeconds(1L))))
-                .isInstanceOf(InvalidReservationException.class)
-                .hasMessage("유효하지 않은 일정입니다.");
-    }
+        @DisplayName("예약이 성공적으로 생성되면 알림을 전송한다.")
+        @Test
+        void sendMessageThenSaveReservation() {
+            Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+            Coupon coupon = couponRepository.save(
+                    new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+            reservationService.save(receiver.getId(),
+                    new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L)));
 
-    @DisplayName("예약시 쿠폰이 존재하지 않을 경우 에외가 발생한다.")
-    @Test
-    void isExistedCoupon() {
-        Member member = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+            AlarmMessageRequest request = AlarmManager.getResources();
 
-        assertThatThrownBy(() -> reservationService.save(member.getId(),
-                new ReservationRequest(3L, LocalDateTime.now().plusDays(1L))))
-                .isInstanceOf(InvalidCouponException.class)
-                .hasMessage("존재하지 않는 쿠폰입니다.");
-    }
+            assertAll(
+                    () -> assertThat(request.getEmails()).containsExactly(LALA_EMAIL),
+                    () -> assertThat(request.getAlarmMessage()).isEqualTo(AlarmMessage.RECEIVE_RESERVATION)
+            );
+        }
 
-    @DisplayName("예약을 보내는 회원이 쿠폰을 받은 회원이 아닐 경우 예외가 발생한다.")
-    @Test
-    void isSameReceiver() {
-        Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
-        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
-        Member other = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
+        @DisplayName("예약시 현재 이전일 경우 실패한다.")
+        @Test
+        void saveTimeFailed() {
+            Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+            Coupon coupon = couponRepository.save(
+                    new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
 
-        Coupon coupon = couponRepository.save(
-                new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+            assertThatThrownBy(() ->
+                    reservationService.save(receiver.getId(),
+                            new ReservationRequest(coupon.getId(), LocalDateTime.now().minusSeconds(1L))))
+                    .isInstanceOf(InvalidReservationException.class)
+                    .hasMessage("유효하지 않은 일정입니다.");
+        }
 
-        assertThatThrownBy(() -> reservationService.save(other.getId(),
-                new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L))))
-                .isInstanceOf(InvalidReservationException.class)
-                .hasMessage("예약을 요청할 수 없는 회원입니다.");
+        @DisplayName("예약시 쿠폰이 존재하지 않을 경우 에외가 발생한다.")
+        @Test
+        void isExistedCoupon() {
+            Member member = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+
+            assertThatThrownBy(() -> reservationService.save(member.getId(),
+                    new ReservationRequest(3L, LocalDateTime.now().plusDays(1L))))
+                    .isInstanceOf(InvalidCouponException.class)
+                    .hasMessage("존재하지 않는 쿠폰입니다.");
+        }
+
+        @DisplayName("예약을 보내는 회원이 쿠폰을 받은 회원이 아닐 경우 예외가 발생한다.")
+        @Test
+        void isSameReceiver() {
+            Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+            Member other = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
+
+            Coupon coupon = couponRepository.save(
+                    new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+
+            assertThatThrownBy(() -> reservationService.save(other.getId(),
+                    new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L))))
+                    .isInstanceOf(InvalidReservationException.class)
+                    .hasMessage("예약을 요청할 수 없는 회원입니다.");
+        }
     }
 
     @DisplayName("예약을 승인한다.")
@@ -138,6 +164,26 @@ class ReservationServiceTest {
         );
     }
 
+    @DisplayName("예약을 승인되면 알람을 전송한다.")
+    @Test
+    void sendMessageThenUpdateStatusAccept() {
+        Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+        Coupon coupon = couponRepository.save(
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+        Long reservationId = reservationService.save(receiver.getId(),
+                new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L)));
+
+        reservationService.updateStatus(sender.getId(), reservationId, new ReservationStatusRequest("accept"));
+
+        AlarmMessageRequest request = AlarmManager.getResources();
+
+        assertAll(
+                () -> assertThat(request.getEmails()).containsExactly(SKRR_EMAIL),
+                () -> assertThat(request.getAlarmMessage()).isEqualTo(AlarmMessage.RESPONSE_RESERVATION)
+        );
+    }
+
     @DisplayName("예약을 거절한다.")
     @Test
     void updateStatusDeny() {
@@ -155,6 +201,27 @@ class ReservationServiceTest {
         assertAll(
                 () -> assertThat(foundReservation.getReservationStatus()).isEqualTo(ReservationStatus.DENY),
                 () -> assertThat(meetingRepository.findAll()).hasSize(0)
+        );
+    }
+
+
+    @DisplayName("예약을 승인되면 알람을 전송한다.")
+    @Test
+    void sendMessageThenUpdateStatusDeny() {
+        Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+        Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+        Coupon coupon = couponRepository.save(
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+        Long reservationId = reservationService.save(receiver.getId(),
+                new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L)));
+
+        reservationService.updateStatus(sender.getId(), reservationId, new ReservationStatusRequest("accept"));
+
+        AlarmMessageRequest request = AlarmManager.getResources();
+
+        assertAll(
+                () -> assertThat(request.getEmails()).containsExactly(SKRR_EMAIL),
+                () -> assertThat(request.getAlarmMessage()).isEqualTo(AlarmMessage.RESPONSE_RESERVATION)
         );
     }
 
@@ -180,6 +247,26 @@ class ReservationServiceTest {
                     () -> assertThat(foundReservation.getReservationStatus()).isEqualTo(ReservationStatus.CANCELED),
                     () -> assertThat(couponRepository.findById(coupon.getId()).get().getCouponStatus()).isEqualTo(
                             NOT_USED)
+            );
+        }
+
+        @DisplayName("예약자가 취소에 성공하면 알람을 전송한다.")
+        @Test
+        void sendMessageThenCancel() {
+            Member sender = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
+            Member receiver = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
+            Coupon coupon = couponRepository.save(
+                    new Coupon(sender.getId(), receiver.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+            Long reservationId = reservationService.save(receiver.getId(),
+                    new ReservationRequest(coupon.getId(), LocalDateTime.now().plusDays(1L)));
+
+            reservationService.cancel(receiver.getId(), reservationId);
+
+            AlarmMessageRequest request = AlarmManager.getResources();
+
+            assertAll(
+                    () -> assertThat(request.getEmails()).containsExactly(SKRR_EMAIL),
+                    () -> assertThat(request.getAlarmMessage()).isEqualTo(AlarmMessage.CANCEL_RESERVATION)
             );
         }
 


### PR DESCRIPTION
## 상세 내용
- Member, Coupon, Meeting 관련 일급컬렉션을 생성하여 각 필드를 조회하는 기능을 추가했습니다.
- 스케쥴에서 비즈니스로직을 수행하고 있었는데 이 로직들을 어플리케이션 레이어로 이동시켰습니다.
- 슬랙 userId를 캐싱해두는 InMemorySlackUserRepository에 대한 테스트 케이스를 추가했습니다.
  -  null이 반환되지 못 하도록 수정했는데 이 부분 다른 로직으로 해결할 수 있는지 봐주시면 감사해요.
- 알람이 전송됐는지 threadLocal에서 꺼내는 방식으로 테스트를 진행했어요.


### 알람 예외관련하여 같이 고민해주세요.
사용자의 이메일이 슬랙으로 조회할 수 없는 경우 예외가 발생합니다.
저는 이 부분은 슬랙알림이나 바로 보기 쉬운 로그로 남겨놔야 직접 이메일을 수정해주거나 크루들에게 빠른 피드백이 가능하다고 생각하여
RuntimeException으로 두고 자연스럽게 500에러로 보내게 하여 슬랙 알림이 가도록 생각했는데요.
생각해보니 해당 예외는 이미 백엔드에서 인지하고 있으므로 400대 에러라고 판단이 되었고 이에 관련하여 로그를 어떻게 남길지 같이 고민해보면 좋을 것 가탕요.

Close #268 

