### PR TITLE
feat: 모든 받은 쿠폰 조회 기능

### DIFF
--- a/backend/src/docs/asciidoc/coupon.adoc
+++ b/backend/src/docs/asciidoc/coupon.adoc
@@ -25,6 +25,10 @@
 
 operation::coupons/send[snippets='http-request,http-response']
 
+=== 받은 쿠폰 조회 (ALL)
+
+operation::coupons/received-coupons-all[snippets='http-request,http-response']
+
 === 받은 쿠폰 조회 (사용하지 않음)
 
 operation::coupons/received-coupons-not-used[snippets='http-request,http-response']

--- a/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/CouponStatusGroup.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/coupon/domain/CouponStatusGroup.java
@@ -11,7 +11,9 @@ import lombok.Getter;
 public enum CouponStatusGroup {
 
     NOT_USED("not-used", Arrays.asList(CouponStatus.NOT_USED, CouponStatus.RESERVING, CouponStatus.RESERVED)),
-    USED("used", Arrays.asList(CouponStatus.USED, CouponStatus.EXPIRED));
+    USED("used", Arrays.asList(CouponStatus.USED, CouponStatus.EXPIRED)),
+    ALL("all", Arrays.asList(CouponStatus.NOT_USED, CouponStatus.RESERVING, CouponStatus.RESERVED,
+            CouponStatus.USED, CouponStatus.EXPIRED));
 
     private final String title;
     private final List<CouponStatus> statuses;

--- a/backend/src/test/java/com/woowacourse/thankoo/common/fixtures/CouponFixture.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/common/fixtures/CouponFixture.java
@@ -8,6 +8,7 @@ public class CouponFixture {
 
     public static final String NOT_USED = "not-used";
     public static final String USED = "used";
+    public static final String ALL = "all";
 
     public static final String TITLE_OVER = "abcdefghijklmnopqrstu";
     public static final String MESSAGE_OVER = "abcdefghijklmnopqrstabcdefghijklmnopqrst12345678901abcdefghijklmnopqrstabcdefghijklmnopqrst1234567890";

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponQueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponQueryRepositoryTest.java
@@ -51,12 +51,14 @@ public class CouponQueryRepositoryTest {
         Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
         Member receiver = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, IMAGE_URL));
 
-        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.NOT_USED));
-        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.RESERVED));
-        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.USED));
+        couponRepository.saveAll(List.of(
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.NOT_USED),
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.RESERVED),
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.USED)
+        ));
 
         List<MemberCoupon> memberCoupons = couponQueryRepository.findByReceiverIdAndStatus(
                 receiver.getId(), CouponStatusGroup.findStatusNames(NOT_USED));
@@ -70,17 +72,40 @@ public class CouponQueryRepositoryTest {
         Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
         Member receiver = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, IMAGE_URL));
 
-        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.NOT_USED));
-        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.EXPIRED));
-        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.USED));
+        couponRepository.saveAll(List.of(
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.NOT_USED),
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.RESERVED),
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.USED)
+        ));
 
         List<MemberCoupon> memberCoupons = couponQueryRepository.findByReceiverIdAndStatus(
                 receiver.getId(), CouponStatusGroup.findStatusNames("used"));
 
-        assertThat(memberCoupons).hasSize(2);
+        assertThat(memberCoupons).hasSize(1);
+    }
+
+    @DisplayName("모든 받은 coupon 을 조회한다.")
+    @Test
+    void findByReceiverIdAndStatusAll() {
+        Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
+        Member receiver = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, IMAGE_URL));
+
+        couponRepository.saveAll(List.of(
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.NOT_USED),
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.RESERVED),
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.USED)
+        ));
+
+        List<MemberCoupon> memberCoupons = couponQueryRepository.findByReceiverIdAndStatus(
+                receiver.getId(), CouponStatusGroup.findStatusNames("all"));
+
+        assertThat(memberCoupons).hasSize(3);
     }
 
     @DisplayName("보낸 coupon 을 조회한다.")
@@ -88,12 +113,14 @@ public class CouponQueryRepositoryTest {
     void findBySenderId() {
         Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
         Member receiver = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, IMAGE_URL));
-        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.NOT_USED));
-        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.RESERVED));
-        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.USED));
+        couponRepository.saveAll(List.of(
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.NOT_USED),
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.RESERVED),
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.USED)
+        ));
 
         List<MemberCoupon> memberCoupons = couponQueryRepository.findBySenderId(sender.getId());
 
@@ -121,16 +148,19 @@ public class CouponQueryRepositoryTest {
     void getCouponCount() {
         Member sender = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL));
         Member receiver = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, IMAGE_URL));
-        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.NOT_USED));
-        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.RESERVED));
-        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.USED));
-        couponRepository.save(new Coupon(receiver.getId(), sender.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.RESERVED));
-        couponRepository.save(new Coupon(receiver.getId(), sender.getId(),
-                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.USED));
+
+        couponRepository.saveAll(List.of(
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.NOT_USED),
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.RESERVED),
+                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.USED),
+                new Coupon(receiver.getId(), sender.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.RESERVED),
+                new Coupon(receiver.getId(), sender.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
+                        CouponStatus.USED)
+        ));
 
         CouponTotal couponTotal = couponQueryRepository.getCouponCount(sender.getId());
         assertAll(

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponStatusGroupTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/domain/CouponStatusGroupTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.thankoo.coupon.domain;
 
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.ALL;
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.NOT_USED;
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.USED;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,8 +35,11 @@ class CouponStatusGroupTest {
 
     private static Stream<Arguments> provideRightStatusNames() {
         return Stream.of(
-                Arguments.of(NOT_USED, List.of(CouponStatus.NOT_USED.name(), CouponStatus.RESERVING.name(), CouponStatus.RESERVED.name())),
-                Arguments.of(USED, List.of(CouponStatus.USED.name(), CouponStatus.EXPIRED.name()))
+                Arguments.of(NOT_USED, List.of(CouponStatus.NOT_USED.name(), CouponStatus.RESERVING.name(),
+                        CouponStatus.RESERVED.name())),
+                Arguments.of(USED, List.of(CouponStatus.USED.name(), CouponStatus.EXPIRED.name())),
+                Arguments.of(ALL, List.of(CouponStatus.NOT_USED.name(), CouponStatus.RESERVING.name(),
+                        CouponStatus.RESERVED.name(), CouponStatus.USED.name(), CouponStatus.EXPIRED.name()))
         );
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/coupon/presentation/CouponControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/coupon/presentation/CouponControllerTest.java
@@ -1,6 +1,7 @@
 package com.woowacourse.thankoo.coupon.presentation;
 
 
+import static com.woowacourse.thankoo.common.fixtures.CouponFixture.ALL;
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.MESSAGE;
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.NOT_USED;
 import static com.woowacourse.thankoo.common.fixtures.CouponFixture.TITLE;
@@ -165,6 +166,54 @@ public class CouponControllerTest extends ControllerTest {
                         content().string(objectMapper.writeValueAsString(couponResponses)));
 
         resultActions.andDo(document("coupons/received-coupons-used",
+                getResponsePreprocessor(),
+                requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("token")
+                ),
+                responseFields(
+                        fieldWithPath("[].couponId").type(NUMBER).description("couponId"),
+                        fieldWithPath("[].sender.id").type(NUMBER).description("senderId"),
+                        fieldWithPath("[].sender.name").type(STRING).description("senderName"),
+                        fieldWithPath("[].sender.email").type(STRING).description("senderEmail"),
+                        fieldWithPath("[].sender.imageUrl").type(STRING).description("senderImageUrl"),
+                        fieldWithPath("[].receiver.id").type(NUMBER).description("receiverId"),
+                        fieldWithPath("[].receiver.name").type(STRING).description("receiverName"),
+                        fieldWithPath("[].receiver.email").type(STRING).description("receiverEmail"),
+                        fieldWithPath("[].receiver.imageUrl").type(STRING).description("receiverImageUrl"),
+                        fieldWithPath("[].content.couponType").type(STRING).description("couponType"),
+                        fieldWithPath("[].content.title").type(STRING).description("title"),
+                        fieldWithPath("[].content.message").type(STRING).description("message"),
+                        fieldWithPath("[].status").type(STRING).description("status")
+                )
+        ));
+    }
+
+    @DisplayName("모든 받은 쿠폰을 조회한다.")
+    @Test
+    void getReceivedCouponsAll() throws Exception {
+        given(jwtTokenProvider.getPayload(anyString()))
+                .willReturn("1");
+        Member huni = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, IMAGE_URL);
+        Member lala = new Member(2L, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL);
+
+        List<CouponResponse> couponResponses = List.of(
+                CouponResponse.of(new MemberCoupon(1L, huni, lala, TYPE, TITLE, MESSAGE, "NOT_USED")),
+                CouponResponse.of(new MemberCoupon(2L, huni, lala, TYPE, TITLE, MESSAGE, "RESERVED")),
+                CouponResponse.of(new MemberCoupon(1L, huni, lala, TYPE, TITLE, MESSAGE, "USED")),
+                CouponResponse.of(new MemberCoupon(2L, huni, lala, TYPE, TITLE, MESSAGE, "EXPIRED"))
+        );
+
+        given(couponQueryService.getReceivedCoupons(anyLong(), anyString()))
+                .willReturn(couponResponses);
+        ResultActions resultActions = mockMvc.perform(get("/api/coupons/received?status=" + ALL)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpectAll(
+                        status().isOk(),
+                        content().string(objectMapper.writeValueAsString(couponResponses)));
+
+        resultActions.andDo(document("coupons/received-coupons-all",
                 getResponsePreprocessor(),
                 requestHeaders(
                         headerWithName(HttpHeaders.AUTHORIZATION).description("token")

--- a/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingQueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/meeting/domain/MeetingQueryRepositoryTest.java
@@ -70,14 +70,12 @@ class MeetingQueryRepositoryTest {
         Member lala = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, IMAGE_URL));
         Member skrr = memberRepository.save(new Member(SKRR_NAME, SKRR_EMAIL, SKRR_SOCIAL_ID, IMAGE_URL));
 
-        Coupon coupon1 = couponRepository.save(
-                new Coupon(lala.getId(), skrr.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
-        Coupon coupon2 = couponRepository.save(
-                new Coupon(lala.getId(), skrr.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
-        Coupon coupon3 = couponRepository.save(
-                new Coupon(lala.getId(), skrr.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED));
+        List<Coupon> coupons = couponRepository.saveAll(List.of(
+                new Coupon(lala.getId(), skrr.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED),
+                new Coupon(lala.getId(), skrr.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED),
+                new Coupon(lala.getId(), skrr.getId(), new CouponContent(COFFEE, TITLE, MESSAGE), NOT_USED))
+        );
 
-        List<Coupon> coupons = List.of(coupon1, coupon2, coupon3);
         LocalDateTime meetingDate = LocalDateTime.now().plusDays(1L);
 
         for (Coupon coupon : coupons) {
@@ -87,8 +85,10 @@ class MeetingQueryRepositoryTest {
             reservation.update(lala, ReservationStatus.ACCEPT, reservedMeetingCreator);
         }
 
-        MeetingQueryCondition condition = new MeetingQueryCondition(lala.getId(), LocalDateTime.now(), MeetingStatus.ON_PROGRESS.name());
-        List<MeetingCoupon> meetingsByMembers = meetingQueryRepository.findMeetingsByMemberIdAndTimeAndStatus(condition);
+        MeetingQueryCondition condition = new MeetingQueryCondition(lala.getId(), LocalDateTime.now(),
+                MeetingStatus.ON_PROGRESS.name());
+        List<MeetingCoupon> meetingsByMembers = meetingQueryRepository.findMeetingsByMemberIdAndTimeAndStatus(
+                condition);
 
         assertAll(
                 () -> assertThat(meetingsByMembers).hasSize(3),


### PR DESCRIPTION
## 상세 내용
### 모든 받은 쿠폰 조회 기능
- GET /api/coupons/received?status=all
- CouponStatusGroup 에 ALL 그룹을 추가했습니다.

### 테스트 코드
- 테스트 코드에서 쿠폰을 여러 개 저장할 때 save() 를 여러번 호출하는 경우 saveAll()로 저장하도록 변경했습니다.
- 트랜잭션을 여러번 생성하지 않아도 되기 때문에 이 방법을 선택했습니다.
```
        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.NOT_USED));
        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.RESERVED));
        couponRepository.save(new Coupon(sender.getId(), receiver.getId(),
                new CouponContent(TYPE, TITLE, MESSAGE), CouponStatus.USED));
```
```
        couponRepository.saveAll(List.of(
                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
                        CouponStatus.NOT_USED),
                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
                        CouponStatus.RESERVED),
                new Coupon(sender.getId(), receiver.getId(), new CouponContent(TYPE, TITLE, MESSAGE),
                        CouponStatus.USED)
        ));
```

Close #286 

