### PR TITLE
feat: 모달창 마운트, 언마운트시 애니메이션 장착

### DIFF
--- a/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
+++ b/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
@@ -1,12 +1,20 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { useEffect } from 'react';
 import useModal from '../../hooks/useModal';
 
 const ConfirmReservationModal = ({ submit, time, date, receiver }) => {
-  const { visible, close } = useModal();
+  const { visible, close, modalContentRef } = useModal();
+
+  useEffect(() => {
+    if (modalContentRef.current) {
+      const target = modalContentRef.current;
+      target?.classList.add('onMount');
+    }
+  }, []);
 
   return (
-    <S.Container show={visible}>
+    <S.Container show={visible} ref={modalContentRef}>
       <S.Wrapper>
         <S.ConfirmHeaderText>예약 정보를 확인해주세요</S.ConfirmHeaderText>
         <S.ConfirmContentWrapper>
@@ -46,7 +54,7 @@ type ButtonProps = {
 const S = {
   Container: styled.div<ConfirmReservationModalProps>`
     position: fixed;
-    bottom: -100%;
+    bottom: 0;
     left: 50%;
     transform: translateX(-50%);
     max-width: 680px;
@@ -58,12 +66,27 @@ const S = {
     z-index: 10000;
     color: white;
 
-    transition: all ease-in-out 0.5s;
     ${({ show }) =>
       show &&
       css`
         bottom: 0;
       `};
+
+    //onMount animation
+    @keyframes myonmount {
+      0% {
+        bottom: -100%;
+      }
+      40% {
+        bottom: -60%;
+      }
+      100% {
+        bottom: 0;
+      }
+    }
+    &.onMount {
+      animation: myonmount 500ms ease-in-out;
+    }
   `,
   Wrapper: styled.div`
     display: flex;

--- a/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
+++ b/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import useModal from '../../hooks/useModal';
 import { modalMountTime, modalUnMountTime } from './../../constants/modal';
@@ -59,19 +58,13 @@ const S = {
     z-index: 10000;
     color: white;
 
-    ${({ show }) =>
-      show &&
-      css`
-        bottom: 0;
-      `};
-
     //onMount animation
     @keyframes myonmount {
       0% {
         bottom: -100%;
       }
       40% {
-        bottom: -60%;
+        bottom: -50%;
       }
       100% {
         bottom: 0;

--- a/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
+++ b/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
@@ -1,18 +1,10 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useEffect } from 'react';
 import useModal from '../../hooks/useModal';
 import { modalMountTime, modalUnMountTime } from './../../constants/modal';
 
 const ConfirmReservationModal = ({ submit, time, date, receiver }) => {
   const { visible, close, modalContentRef } = useModal();
-
-  useEffect(() => {
-    if (modalContentRef.current) {
-      const target = modalContentRef.current;
-      target?.classList.add('onMount');
-    }
-  }, []);
 
   return (
     <S.Container show={visible} ref={modalContentRef}>

--- a/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
+++ b/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useEffect } from 'react';
 import useModal from '../../hooks/useModal';
+import { modalMountTime, modalUnMountTime } from './../../constants/modal';
 
 const ConfirmReservationModal = ({ submit, time, date, receiver }) => {
   const { visible, close, modalContentRef } = useModal();
@@ -85,7 +86,7 @@ const S = {
       }
     }
     &.onMount {
-      animation: myonmount 500ms ease-in-out;
+      animation: myonmount ${`${modalMountTime}ms`} ease-in-out;
     }
 
     //unMount animation
@@ -98,7 +99,7 @@ const S = {
       }
     }
     &.unMount {
-      animation: myunmount 200ms ease-in-out;
+      animation: myunmount ${`${modalUnMountTime}ms`} ease-in-out;
     }
   `,
   Wrapper: styled.div`

--- a/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
+++ b/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
@@ -87,6 +87,19 @@ const S = {
     &.onMount {
       animation: myonmount 500ms ease-in-out;
     }
+
+    //unMount animation
+    @keyframes myunmount {
+      0% {
+        bottom: 0%;
+      }
+      100% {
+        bottom: -100%;
+      }
+    }
+    &.unMount {
+      animation: myunmount 200ms ease-in-out;
+    }
   `,
   Wrapper: styled.div`
     display: flex;

--- a/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
+++ b/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { modalUnMountTime } from '../../constants/modal';
 import useModal from '../../hooks/useModal';
@@ -75,12 +74,6 @@ const S = {
     display: flex;
     z-index: 10000;
     color: white;
-
-    ${({ show }) =>
-      show &&
-      css`
-        bottom: 0;
-      `};
 
     //onMount animation
     @keyframes myonmount {

--- a/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
+++ b/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import { useEffect } from 'react';
 import useModal from '../../hooks/useModal';
 import { UserProfile } from '../../types';
 
@@ -14,10 +15,17 @@ const ConfirmCouponContentModal = ({
   title: string;
   receivers: UserProfile[];
 }) => {
-  const { visible, close } = useModal();
+  const { visible, close, modalContentRef } = useModal();
+
+  useEffect(() => {
+    if (modalContentRef.current) {
+      const target = modalContentRef.current;
+      target?.classList.add('onMount');
+    }
+  }, []);
 
   return (
-    <S.Container show={visible}>
+    <S.Container show={visible} ref={modalContentRef}>
       <S.Wrapper>
         <S.ConfirmHeaderText>쿠폰 정보를 확인해주세요</S.ConfirmHeaderText>
         <S.ConfirmContentWrapper>
@@ -62,7 +70,7 @@ type ButtonProps = {
 const S = {
   Container: styled.div<ConfirmCouponContentModalProps>`
     position: fixed;
-    bottom: -100%;
+    bottom: 0;
     left: 50%;
     transform: translateX(-50%);
     max-width: 680px;
@@ -74,12 +82,27 @@ const S = {
     z-index: 10000;
     color: white;
 
-    transition: all ease-in-out 0.5s;
     ${({ show }) =>
       show &&
       css`
         bottom: 0;
       `};
+
+    //onMount animation
+    @keyframes myonmount {
+      0% {
+        bottom: -100%;
+      }
+      40% {
+        bottom: -60%;
+      }
+      100% {
+        bottom: 0;
+      }
+    }
+    &.onMount {
+      animation: myonmount 500ms ease-in-out;
+    }
   `,
   Wrapper: styled.div`
     display: flex;

--- a/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
+++ b/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useEffect } from 'react';
 import { modalUnMountTime } from '../../constants/modal';
 import useModal from '../../hooks/useModal';
 import { UserProfile } from '../../types';
@@ -18,13 +17,6 @@ const ConfirmCouponContentModal = ({
   receivers: UserProfile[];
 }) => {
   const { visible, close, modalContentRef } = useModal();
-
-  useEffect(() => {
-    if (modalContentRef.current) {
-      const target = modalContentRef.current;
-      target?.classList.add('modalContainer', 'onMount');
-    }
-  }, []);
 
   return (
     <S.Container show={visible} ref={modalContentRef}>

--- a/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
+++ b/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
@@ -103,6 +103,19 @@ const S = {
     &.onMount {
       animation: myonmount 500ms ease-in-out;
     }
+
+    //unMount animation
+    @keyframes myunmount {
+      0% {
+        bottom: 0%;
+      }
+      100% {
+        bottom: -100%;
+      }
+    }
+    &.unMount {
+      animation: myunmount 200ms ease-in-out;
+    }
   `,
   Wrapper: styled.div`
     display: flex;

--- a/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
+++ b/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
@@ -1,8 +1,10 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useEffect } from 'react';
+import { modalUnMountTime } from '../../constants/modal';
 import useModal from '../../hooks/useModal';
 import { UserProfile } from '../../types';
+import { modalMountTime } from './../../constants/modal';
 
 const ConfirmCouponContentModal = ({
   submit,
@@ -20,7 +22,7 @@ const ConfirmCouponContentModal = ({
   useEffect(() => {
     if (modalContentRef.current) {
       const target = modalContentRef.current;
-      target?.classList.add('onMount');
+      target?.classList.add('modalContainer', 'onMount');
     }
   }, []);
 
@@ -101,7 +103,7 @@ const S = {
       }
     }
     &.onMount {
-      animation: myonmount 500ms ease-in-out;
+      animation: myonmount ${`${modalMountTime}ms`} ease-in-out;
     }
 
     //unMount animation
@@ -114,7 +116,7 @@ const S = {
       }
     }
     &.unMount {
-      animation: myunmount 200ms ease-in-out;
+      animation: myunmount ${`${modalUnMountTime}ms`} ease-in-out;
     }
   `,
   Wrapper: styled.div`

--- a/frontend/src/constants/modal.ts
+++ b/frontend/src/constants/modal.ts
@@ -1,0 +1,2 @@
+export const modalMountTime = 500;
+export const modalUnMountTime = 200;

--- a/frontend/src/hooks/useModal.ts
+++ b/frontend/src/hooks/useModal.ts
@@ -10,8 +10,16 @@ const useModal = () => {
   const show = () => {
     setVisible(true);
   };
+
   const close = () => {
-    setVisible(false);
+    //dimmer 클릭했을땐 targe null....
+    const target = modalContentRef.current;
+    target?.classList.remove('onMount');
+    target?.classList.add('unMount');
+
+    setTimeout(() => {
+      setVisible(false);
+    }, 200);
   };
 
   return { show, close, visible, setModalContent, modalContentRef };

--- a/frontend/src/hooks/useModal.ts
+++ b/frontend/src/hooks/useModal.ts
@@ -1,9 +1,11 @@
+import { useRef } from 'react';
 import { useRecoilState } from 'recoil';
 import { modalContentAtom, modalVisibleAtom } from '../recoil/atom';
 
 const useModal = () => {
   const [visible, setVisible] = useRecoilState(modalVisibleAtom);
   const [modalContent, setModalContent] = useRecoilState(modalContentAtom);
+  const modalContentRef = useRef<HTMLDivElement>(null);
 
   const show = () => {
     setVisible(true);
@@ -12,7 +14,7 @@ const useModal = () => {
     setVisible(false);
   };
 
-  return { show, close, visible, setModalContent };
+  return { show, close, visible, setModalContent, modalContentRef };
 };
 
 export default useModal;

--- a/frontend/src/hooks/useModal.ts
+++ b/frontend/src/hooks/useModal.ts
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import { useRecoilState } from 'recoil';
+import { modalUnMountTime } from '../constants/modal';
 import { modalContentAtom, modalVisibleAtom } from '../recoil/atom';
 
 const useModal = () => {
@@ -12,14 +13,13 @@ const useModal = () => {
   };
 
   const close = () => {
-    //dimmer 클릭했을땐 targe null....
-    const target = modalContentRef.current;
+    const target = document.getElementsByClassName('onMount modalContainer')[0];
     target?.classList.remove('onMount');
     target?.classList.add('unMount');
 
     setTimeout(() => {
       setVisible(false);
-    }, 200);
+    }, modalUnMountTime);
   };
 
   return { show, close, visible, setModalContent, modalContentRef };

--- a/frontend/src/hooks/useModal.ts
+++ b/frontend/src/hooks/useModal.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRecoilState } from 'recoil';
 import { modalUnMountTime } from '../constants/modal';
 import { modalContentAtom, modalVisibleAtom } from '../recoil/atom';
@@ -7,6 +7,13 @@ const useModal = () => {
   const [visible, setVisible] = useRecoilState(modalVisibleAtom);
   const [modalContent, setModalContent] = useRecoilState(modalContentAtom);
   const modalContentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (modalContentRef.current) {
+      const target = modalContentRef.current;
+      target?.classList.add('modalContainer', 'onMount');
+    }
+  }, []);
 
   const show = () => {
     setVisible(true);


### PR DESCRIPTION
## 상세 내용
- Mount Animation
![mount Animation](https://user-images.githubusercontent.com/72348351/184943251-2fb97f82-582d-44a5-945f-6da6e0afb2c7.gif)


- UnMount Animation
![unmount Animation](https://user-images.githubusercontent.com/72348351/184943275-32e041c1-869e-4a9a-9398-56c9dfed443b.gif)


## 사용법
최대한 재사용 가능하게 useModal을 변경하였습니다.
사용하고자 하는 Modal Content Component의 최상단 div (대부분의경우 S.container)에 ref={modalContentRef} 를 달아주고
S.Container 안에서 animation 정의만 해주면 됩니다.

ex)
```javascript 
const ConfirmCouponContentModal = () => {

    return <S.Container show={visible} ref={modalContentRef}> ...... </S.Container>
}

const S = {
  Container: styled.div`
    //onMount animation
    @keyframes myonmount {
      0% {
        bottom: -100%;
      }
      40% {
        bottom: -60%;
      }
      100% {
        bottom: 0;
      }
    }
    &.onMount {
      animation: myonmount ${`${modalMountTime}ms`} ease-in-out;
    }

    //unMount animation
    @keyframes myunmount {
      0% {
        bottom: 0%;
      }
      100% {
        bottom: -100%;
      }
    }
    &.unMount {
      animation: myunmount ${`${modalUnMountTime}ms`} ease-in-out;
    }
  `,

```

## 코드에서 봐줬으면 좋겠는 사항
- useModal의 close에서 최대한 추상화 하다보니까 document.getElementByClassName을 쓰게 됐습니다.
ref로 처리하려고 했는데, 호출할때 dimmer를 클릭하는 경우에 useModal이 새로 호출이 돼서 ref가 null로 초기화 돼 버리더군요..
전역상태로 선언할까 하다가 차라리 document 접근도 괜찮겠다 싶어서 

```javascript
  const close = () => {
    const target = document.getElementsByClassName('onMount modalContainer')[0];
    target?.classList.remove('onMount');
    target?.classList.add('unMount');

    setTimeout(() => {
      setVisible(false);
    }, modalUnMountTime);
  };
```
처럼 사용하고 있습니다.

- modal마다 time을 줄까 하다가,, 그냥 const 로 modal mount와 unmount를 관리해서
animation이 적용되는 modal은 마운트시간, 언마운트 시간은 동일하게 사용하고 있습니다.
이의제기 가능합니다.

Close #292 
