### PR TITLE
refactor: 회원 이름 변경 api url 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/thankoo/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/presentation/MemberController.java
@@ -30,7 +30,7 @@ public class MemberController {
         return ResponseEntity.ok(memberService.getMember(memberId));
     }
 
-    @PutMapping("/me")
+    @PutMapping("/me/name")
     public ResponseEntity<Void> updateMemberName(@AuthenticationPrincipal final Long memberId,
                                                  @RequestBody final MemberNameRequest memberNameRequest) {
         memberService.updateMemberName(memberId, memberNameRequest);

--- a/backend/src/test/java/com/woowacourse/thankoo/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/acceptance/MemberAcceptanceTest.java
@@ -67,7 +67,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
                 .token();
 
         MemberAssured.request()
-                .내_정보를_수정한다(tokenResponse, new MemberNameRequest(HUNI_NAME))
+                .내_이름_정보를_수정한다(tokenResponse, new MemberNameRequest(HUNI_NAME))
                 .response()
                 .status(HttpStatus.NO_CONTENT.value());
 

--- a/backend/src/test/java/com/woowacourse/thankoo/acceptance/builder/MemberAssured.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/acceptance/builder/MemberAssured.java
@@ -35,9 +35,9 @@ public class MemberAssured {
             return this;
         }
 
-        public MemberRequestBuilder 내_정보를_수정한다(final TokenResponse tokenResponse,
-                                               final MemberNameRequest memberNameRequest) {
-            response = putWithToken("/api/members/me", tokenResponse.getAccessToken(), memberNameRequest);
+        public MemberRequestBuilder 내_이름_정보를_수정한다(final TokenResponse tokenResponse,
+                                                  final MemberNameRequest memberNameRequest) {
+            response = putWithToken("/api/members/me/name", tokenResponse.getAccessToken(), memberNameRequest);
             return this;
         }
 

--- a/backend/src/test/java/com/woowacourse/thankoo/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/presentation/MemberControllerTest.java
@@ -113,7 +113,7 @@ public class MemberControllerTest extends ControllerTest {
         MemberNameRequest memberNameRequest = new MemberNameRequest(LALA_NAME);
         doNothing().when(memberService).updateMemberName(anyLong(), any(MemberNameRequest.class));
 
-        ResultActions resultActions = mockMvc.perform(put("/api/members/me")
+        ResultActions resultActions = mockMvc.perform(put("/api/members/me/name")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 상세 내용
- 회원 이름 api url을 /api/members/me 에서 /api/members/me/name 으로 수정했습니다.

Close #295 

