### PR TITLE
feat: 메인 페이지 받은, 보낸 쿠폰함 한번에 보이기

### DIFF
--- a/frontend/src/components/@shared/HeaderText.tsx
+++ b/frontend/src/components/@shared/HeaderText.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-const HeaderText = styled.div`
-  font-size: 22px;
+const HeaderText = styled.span`
+  font-size: 20px;
   display: flex;
   align-items: center;
 `;

--- a/frontend/src/components/@shared/noContent/NoReceivedCoupon.tsx
+++ b/frontend/src/components/@shared/noContent/NoReceivedCoupon.tsx
@@ -8,7 +8,9 @@ const NoReceivedCoupon = () => {
   return (
     <S.Container>
       <S.Box>
-        <IconEmptyList />
+        <S.IconWrapper>
+          <IconEmptyList />
+        </S.IconWrapper>
         <S.Comment>
           받은 쿠폰이 없어요🤣
           <br />
@@ -34,12 +36,14 @@ const S = {
     flex-direction: column;
     width: 280px;
     height: fit-content;
-    background-color: #1d1d1d;
     border-radius: 10px;
     color: ${({ theme }) => theme.header.color};
     text-align: center;
     gap: 8px;
     padding: 30px 10px;
+  `,
+  IconWrapper: styled.div`
+    height: 70px;
   `,
   Comment: styled.h3`
     line-height: 30px;

--- a/frontend/src/components/@shared/noContent/NoReservation copy.tsx
+++ b/frontend/src/components/@shared/noContent/NoReservation copy.tsx
@@ -6,7 +6,9 @@ const NoReservation = () => {
   return (
     <S.Container>
       <S.Box>
-        <IconEmptyList />
+        <S.IconWrapper>
+          <IconEmptyList />
+        </S.IconWrapper>
         <S.Comment>
           예약이 없네요👻
           <br />
@@ -35,6 +37,9 @@ const S = {
     text-align: center;
     gap: 8px;
     padding: 30px 10px;
+  `,
+  IconWrapper: styled.div`
+    height: 70px;
   `,
   Comment: styled.h3`
     line-height: 30px;

--- a/frontend/src/components/@shared/noContent/NoSendCoupon.tsx
+++ b/frontend/src/components/@shared/noContent/NoSendCoupon.tsx
@@ -8,7 +8,9 @@ const NoSendCoupon = () => {
   return (
     <S.Container>
       <S.Box>
-        <IconEmptyList />
+        <S.IconWrapper>
+          <IconEmptyList />
+        </S.IconWrapper>
         <S.Comment>
           보낸 쿠폰이 없어요😥
           <br />
@@ -34,12 +36,14 @@ const S = {
     flex-direction: column;
     width: 280px;
     height: fit-content;
-    background-color: #1d1d1d;
     border-radius: 10px;
     color: ${({ theme }) => theme.header.color};
     text-align: center;
     gap: 8px;
     padding: 30px 10px;
+  `,
+  IconWrapper: styled.div`
+    height: 70px;
   `,
   Comment: styled.h3`
     line-height: 30px;

--- a/frontend/src/hooks/Main/domain/useMain.ts
+++ b/frontend/src/hooks/Main/domain/useMain.ts
@@ -18,8 +18,6 @@ const useMain = () => {
 
   const { data, isLoading, error } = useGetCoupons(sentOrReceived);
 
-  console.log(data);
-
   const edittedCouponsBySentOrReceived =
     sentOrReceived === '보낸'
       ? data?.map(coupon => {

--- a/frontend/src/hooks/Main/domain/useMain.ts
+++ b/frontend/src/hooks/Main/domain/useMain.ts
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useQueryClient } from 'react-query';
 import { useRecoilState } from 'recoil';
 import { sentOrReceivedAtom } from '../../../recoil/atom';
 import { CouponType } from '../../../types';
@@ -16,6 +17,8 @@ const useMain = () => {
   const [currentType, setCurrentType] = useState<CouponType>('entire');
 
   const { data, isLoading, error } = useGetCoupons(sentOrReceived);
+
+  console.log(data);
 
   const edittedCouponsBySentOrReceived =
     sentOrReceived === '보낸'

--- a/frontend/src/hooks/Main/domain/useMain.ts
+++ b/frontend/src/hooks/Main/domain/useMain.ts
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-import { useQueryClient } from 'react-query';
+import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { sentOrReceivedAtom } from '../../../recoil/atom';
 import { CouponType } from '../../../types';

--- a/frontend/src/hooks/Main/queries/coupons.ts
+++ b/frontend/src/hooks/Main/queries/coupons.ts
@@ -23,18 +23,12 @@ export const useGetCoupons = sentOrReceived => {
     });
   }, []);
 
-  return useQuery<Coupon[]>(
-    ['coupon', sentOrReceived],
-    async () => {
-      const { data } = await client({
-        method: 'get',
-        url: SENT_OR_RECEIVED_API_PATH[sentOrReceived],
-      });
+  return useQuery<Coupon[]>(['coupon', sentOrReceived], async () => {
+    const { data } = await client({
+      method: 'get',
+      url: SENT_OR_RECEIVED_API_PATH[sentOrReceived],
+    });
 
-      return data;
-    },
-    {
-      keepPreviousData: true,
-    }
-  );
+    return data;
+  });
 };

--- a/frontend/src/hooks/Main/queries/coupons.ts
+++ b/frontend/src/hooks/Main/queries/coupons.ts
@@ -1,4 +1,5 @@
-import { useQuery } from 'react-query';
+import { useEffect } from 'react';
+import { useQuery, useQueryClient } from 'react-query';
 import { client } from '../../../apis/axios';
 import { API_PATH } from '../../../constants/api';
 import { Coupon } from '../../../types';
@@ -8,11 +9,32 @@ const SENT_OR_RECEIVED_API_PATH = {
   보낸: API_PATH.SENT_COUPONS,
 };
 
-export const useGetCoupons = sentOrReceived =>
-  useQuery<Coupon[]>(['coupon', sentOrReceived], async () => {
-    const { data } = await client({
-      method: 'get',
-      url: SENT_OR_RECEIVED_API_PATH[sentOrReceived],
+export const useGetCoupons = sentOrReceived => {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    queryClient.prefetchQuery(['coupon', '보낸'], async () => {
+      const { data } = await client({
+        method: 'get',
+        url: API_PATH.SENT_COUPONS,
+      });
+
+      return data;
     });
-    return data;
-  });
+  }, []);
+
+  return useQuery<Coupon[]>(
+    ['coupon', sentOrReceived],
+    async () => {
+      const { data } = await client({
+        method: 'get',
+        url: SENT_OR_RECEIVED_API_PATH[sentOrReceived],
+      });
+
+      return data;
+    },
+    {
+      keepPreviousData: true,
+    }
+  );
+};

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -5,8 +5,6 @@ import TabsNav from '../components/@shared/TabsNav';
 import GridViewCoupons from '../components/Main/GridViewCoupons';
 import useMain from '../hooks/Main/domain/useMain';
 
-import ArrowRightIcon from '@mui/icons-material/ArrowRight';
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import Header from '../components/@shared/Header';
 import HeaderText from '../components/@shared/HeaderText';
@@ -19,6 +17,9 @@ import useModal from '../hooks/useModal';
 import { couponTypeKeys, couponTypes } from '../types';
 import NoReceivedCoupon from './../components/@shared/noContent/NoReceivedCoupon';
 import NoSendCoupon from './../components/@shared/noContent/NoSendCoupon';
+import { css } from '@emotion/react';
+
+const sentOrReceivedArray = ['받은', '보낸'];
 
 const Main = () => {
   const {
@@ -30,8 +31,8 @@ const Main = () => {
     sentOrReceived,
     setSentOrReceived,
   } = useMain();
+
   const { visible } = useModal();
-  const [dropdownShow, setDropdownShow] = useState(false);
 
   if (isLoading) return <div>로딩중</div>;
   if (error) return <div>에러뜸</div>;
@@ -43,23 +44,25 @@ const Main = () => {
           <S.UserProfile>
             <UserProfileButton />
           </S.UserProfile>
-          <S.HeaderText
-            onClick={() => {
-              setDropdownShow(prev => !prev);
-            }}
-          >
-            {sentOrReceived} 쿠폰함
-            <ArrowRightIcon />
-            <S.Dropdown show={dropdownShow}>
-              <div
-                onClick={() => {
-                  setSentOrReceived(prev => (prev === '보낸' ? '받은' : '보낸'));
-                }}
-              >
-                {sentOrReceived === '보낸' ? '받은' : '보낸'} 쿠폰함
-              </div>
-            </S.Dropdown>
-          </S.HeaderText>
+          <S.CouponStatusNavWrapper>
+            <S.SliderDiv length={2} current={sentOrReceivedArray.indexOf(sentOrReceived)} />
+            <S.CouponStatusNav
+              onClick={() => {
+                setSentOrReceived('받은');
+              }}
+              selected={sentOrReceived === '받은'}
+            >
+              <S.HeaderText>받은 쿠폰함</S.HeaderText>
+            </S.CouponStatusNav>
+            <S.CouponStatusNav
+              onClick={() => {
+                setSentOrReceived('보낸');
+              }}
+              selected={sentOrReceived === '보낸'}
+            >
+              <S.HeaderText>보낸 쿠폰함</S.HeaderText>
+            </S.CouponStatusNav>
+          </S.CouponStatusNavWrapper>
         </Header>
         <S.Body>
           <TabsNav
@@ -86,9 +89,13 @@ const Main = () => {
     </>
   );
 };
+type SliderDivProps = {
+  length: number;
+  current: number;
+};
 
-type DropdownProps = {
-  show: boolean;
+type CouponStatusNavProps = {
+  selected: boolean;
 };
 
 const S = {
@@ -97,6 +104,37 @@ const S = {
     flex-direction: column;
     gap: 15px;
     padding: 5px 3vw;
+  `,
+  CouponStatusNavWrapper: styled.div`
+    position: relative;
+    display: flex;
+    justify-content: space-around;
+    width: 100%;
+    cursor: pointer;
+  `,
+  SliderDiv: styled.div<SliderDivProps>`
+    width: ${({ length }) => `${100 / length}%`};
+    height: 103%;
+    background-color: white;
+    position: absolute;
+    left: 0;
+    top: 0;
+
+    transition: all ease-in-out 0.1s;
+    left: ${({ current, length }) => `${(100 / length) * current}%`};
+  `,
+  CouponStatusNav: styled.div<CouponStatusNavProps>`
+    display: flex;
+    justify-content: center;
+    z-index: 1;
+    width: 100%;
+    padding: 1rem;
+    background-color: #232323;
+    ${({ selected }) =>
+      !selected &&
+      css`
+        color: #8e8e8e;
+      `};
   `,
   HeaderText: styled(HeaderText)`
     cursor: pointer;
@@ -113,24 +151,6 @@ const S = {
     width: 100%;
     display: flex;
     justify-content: flex-end;
-  `,
-  Dropdown: styled.div<DropdownProps>`
-    position: absolute;
-    display: ${({ show }) => (show ? 'flex' : 'none')};
-    top: -30%;
-    left: 82%;
-    width: 100%;
-    justify-content: center;
-    & > div {
-      font-size: 14px;
-      padding: 15px 10px;
-      border-radius: 2px;
-      display: flex;
-      align-items: center;
-      :hover {
-        background-color: #ff6347;
-      }
-    }
   `,
   SelectReceiverButton: styled(Link)``,
   SendIcon: styled(SendIcon)`


### PR DESCRIPTION
## 상세 내용
- 받은 쿠폰함, 보낸 쿠폰함 nav를 한번에 보여주고 클릭 시 slide animation을 한다
- 빈 페이지 새 그림에 기본 height를 줘서 reflow(icon 공간 없어서 작아져 있다가 늘어 나는 거)를 방지했다.

Close #302 

