### PR TITLE
refactor: 회원 조회시 이메일을 마스킹한다. 

### DIFF
--- a/backend/src/main/java/com/woowacourse/thankoo/authentication/presentation/dto/TokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/authentication/presentation/dto/TokenResponse.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class TokenResponse {
 
+    private static final int DISPLAY_RANGE = 3;
+
     private boolean joined;
     private String accessToken;
     private Long memberId;
@@ -35,7 +37,7 @@ public class TokenResponse {
     public String toString() {
         return "TokenResponse{" +
                 "joined=" + joined +
-                ", accessToken='" + MaskingUtil.mask(accessToken, 3) + '\'' +
+                ", accessToken='" + MaskingUtil.mask(accessToken, DISPLAY_RANGE) + '\'' +
                 ", memberId=" + memberId +
                 ", email='" + email + '\'' +
                 '}';

--- a/backend/src/main/java/com/woowacourse/thankoo/member/presentation/dto/MemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/presentation/dto/MemberResponse.java
@@ -20,7 +20,7 @@ public class MemberResponse {
     private MemberResponse(final Long id, final String name, final String email, final String imageUrl) {
         this.id = id;
         this.name = name;
-        this.email =  MaskingUtil.mask(email, 3);
+        this.email =  MaskingUtil.mask(email, DISPLAY_RANGE);
         this.imageUrl = imageUrl;
     }
 

--- a/backend/src/main/java/com/woowacourse/thankoo/member/presentation/dto/MemberResponse.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/presentation/dto/MemberResponse.java
@@ -1,5 +1,6 @@
 package com.woowacourse.thankoo.member.presentation.dto;
 
+import com.woowacourse.thankoo.common.logging.MaskingUtil;
 import com.woowacourse.thankoo.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MemberResponse {
 
+    private static final int DISPLAY_RANGE = 3;
+
     private Long id;
     private String name;
     private String email;
@@ -17,7 +20,7 @@ public class MemberResponse {
     private MemberResponse(final Long id, final String name, final String email, final String imageUrl) {
         this.id = id;
         this.name = name;
-        this.email = email;
+        this.email =  MaskingUtil.mask(email, 3);
         this.imageUrl = imageUrl;
     }
 

--- a/backend/src/test/java/com/woowacourse/thankoo/common/logging/MaskingUtilTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/common/logging/MaskingUtilTest.java
@@ -11,8 +11,8 @@ class MaskingUtilTest {
     @Test
     @DisplayName("지정된 범위 이후의 문자를 마스킹한다.")
     void mask() {
-        String maskedToken = MaskingUtil.mask("eyJhb.eyJzdWIiOiIxMjM0NTY3ODk.SflKxwRJSMe", 3);
+        String maskedWord = MaskingUtil.mask("eyJhb.eyJzdWIiOiIxMjM0NTY3ODk.SflKxwRJSMe", 3);
 
-        assertThat(maskedToken).isEqualTo("eyJ*******");
+        assertThat(maskedWord).isEqualTo("eyJ*******");
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/common/logging/MaskingUtilTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/common/logging/MaskingUtilTest.java
@@ -1,0 +1,18 @@
+package com.woowacourse.thankoo.common.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("MaskingUtil 은 ")
+class MaskingUtilTest {
+
+    @Test
+    @DisplayName("지정된 범위 이후의 문자를 마스킹한다.")
+    void mask() {
+        String maskedToken = MaskingUtil.mask("eyJhb.eyJzdWIiOiIxMjM0NTY3ODk.SflKxwRJSMe", 3);
+
+        assertThat(maskedToken).isEqualTo("eyJ*******");
+    }
+}


### PR DESCRIPTION
## 상세 내용
- 기존에 만들어진 마스킹유틸 클래스를 활용하여 이메일을 마스킹하고 테스트 코드를 추가했습니다.
- 프론트에서 회원조회 후 이메일가지고 로직을 수행하는 코드가 없겠죠?

Close #356 

