### PR TITLE
refactor: 만남 완료 / 만료된 예약 스케줄링시 시간 설정 방식 변경 

### DIFF
--- a/backend/src/main/java/com/woowacourse/thankoo/common/schedule/MeetingScheduleTask.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/schedule/MeetingScheduleTask.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-@Profile("local")
+@Profile({"prod", "dev"})
 @Component
 @RequiredArgsConstructor
 @Slf4j

--- a/backend/src/main/java/com/woowacourse/thankoo/common/schedule/MeetingScheduleTask.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/schedule/MeetingScheduleTask.java
@@ -3,13 +3,14 @@ package com.woowacourse.thankoo.common.schedule;
 import com.woowacourse.thankoo.meeting.application.MeetingService;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-@Profile("prod")
+@Profile("local")
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -20,7 +21,10 @@ public class MeetingScheduleTask {
     @Scheduled(cron = "0 0/30 10-19 * * *")
     public void executeCompleteMeeting() {
         log.debug("[Scheduling] 당일 만남 완료 처리");
-        meetingService.complete(LocalDateTime.now());
+        LocalDateTime nowDateTime = LocalDateTime.now();
+        LocalTime nowTime = LocalTime.of(nowDateTime.getHour(), nowDateTime.getMinute());
+        LocalDateTime meetingTime = LocalDateTime.of(nowDateTime.toLocalDate(), nowTime);
+        meetingService.complete(meetingTime);
     }
 
     @Scheduled(cron = "0 0 9 * * *")

--- a/backend/src/main/java/com/woowacourse/thankoo/common/schedule/ReservationScheduleTask.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/schedule/ReservationScheduleTask.java
@@ -2,6 +2,7 @@ package com.woowacourse.thankoo.common.schedule;
 
 import com.woowacourse.thankoo.reservation.application.ReservationService;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
@@ -19,6 +20,9 @@ public class ReservationScheduleTask {
     @Scheduled(cron = "0 0/30 10-19 * * *")
     void executeCancelExpiredReservation() {
         log.debug("[Scheduling] 만료된 예약 취소 처리");
-        reservationService.cancelExpiredReservation(LocalDateTime.now());
+        LocalDateTime nowDateTime = LocalDateTime.now();
+        LocalTime nowTime = LocalTime.of(nowDateTime.getHour(), nowDateTime.getMinute());
+        LocalDateTime reservationTime = LocalDateTime.of(nowDateTime.toLocalDate(), nowTime);
+        reservationService.cancelExpiredReservation(reservationTime);
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/common/schedule/ReservationScheduleTask.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/schedule/ReservationScheduleTask.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-@Profile("prod")
+@Profile({"prod", "dev"})
 @Component
 @RequiredArgsConstructor
 @Slf4j

--- a/backend/src/main/java/com/woowacourse/thankoo/meeting/application/MeetingService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/meeting/application/MeetingService.java
@@ -50,9 +50,9 @@ public class MeetingService {
                 .orElseThrow(() -> new InvalidMemberException(ErrorType.NOT_FOUND_MEMBER));
     }
 
-    public void complete(final LocalDateTime dateTime) {
+    public void complete(final LocalDateTime meetingTime) {
         Meetings meetings = new Meetings(
-                meetingRepository.findAllByMeetingStatusAndTimeUnitTime(ON_PROGRESS, dateTime));
+                meetingRepository.findAllByMeetingStatusAndTimeUnitTime(ON_PROGRESS, meetingTime));
         if (meetings.haveMeeting()) {
             Coupons coupons = new Coupons(meetings.getCoupons());
             meetingRepository.updateMeetingStatus(MeetingStatus.FINISHED, meetings.getMeetingIds());

--- a/backend/src/main/java/com/woowacourse/thankoo/reservation/application/ReservationService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/reservation/application/ReservationService.java
@@ -71,9 +71,9 @@ public class ReservationService {
                 .orElseThrow(() -> new InvalidMemberException(ErrorType.NOT_FOUND_MEMBER));
     }
 
-    public void cancelExpiredReservation(final LocalDateTime dateTime) {
+    public void cancelExpiredReservation(final LocalDateTime reservationTime) {
         Reservations reservations = new Reservations(reservationRepository.findAllByReservationStatusAndTimeUnitTime(
-                ReservationStatus.WAITING, dateTime));
+                ReservationStatus.WAITING, reservationTime));
 
         reservationRepository.updateReservationStatus(ReservationStatus.CANCELED, reservations.getIds());
         couponRepository.updateCouponStatus(CouponStatus.NOT_USED, reservations.getCouponIds());


### PR DESCRIPTION
## 문제 상황
```java
    @Scheduled(cron = "0 0/30 10-19 * * *")
    void executeCancelExpiredReservation() {
        log.debug("[Scheduling] 만료된 예약 취소 처리");
        reservationService.cancelExpiredReservation(LocalDateTime.now());
    }
```
- DB 에 `2022-08-05 19:30:00` 와 같이 초 단위가 0으로 저장됨
- `LocalDateTime.now()` 시점의 Time이 0초가 아닐 수 있기 때문에 해당하는 만남/예약 조회시 예상과 다르게 조회되지 않음


## 해결 방안
-  분 단위까지만 현재 시간을 적용하고 초 단위는 0초로 설정하여 처리하도록 수정

```java
    @Scheduled(cron = "0 0/30 10-19 * * *")
    void executeCancelExpiredReservation() {
        log.debug("[Scheduling] 만료된 예약 취소 처리");
        LocalDateTime nowDateTime = LocalDateTime.now();
        LocalTime nowTime = LocalTime.of(nowDateTime.getHour(), nowDateTime.getMinute());
        LocalDateTime reservationTime = LocalDateTime.of(nowDateTime.toLocalDate(), nowTime);
        reservationService.cancelExpiredReservation(reservationTime);
    }
```

Close #421 
