### PR TITLE
feat: 시리얼 번호로 쿠폰 시리얼을 조회한다.

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -21,6 +21,8 @@ include::reservation.adoc[]
 include::meeting.adoc[]
 == Heart
 include::heart.adoc[]
+== Serial
+include::serial.adoc[]
 
 = Admin
 include::admin.adoc[]

--- a/backend/src/docs/asciidoc/serial.adoc
+++ b/backend/src/docs/asciidoc/serial.adoc
@@ -1,6 +1,10 @@
 [[Coupob-Serial]]
 [cols=2*,options=header]
 
+=== 시리얼 조회
+
+operation::coupons/get-serial[snippets='http-request,http-response']
+
 === 시리얼 번호로 쿠폰 생성
 
 operation::coupons/create-with-serial[snippets='http-request,http-response']

--- a/backend/src/main/java/com/woowacourse/thankoo/admin/qrcode/application/AdminQrCodeService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/admin/qrcode/application/AdminQrCodeService.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class AdminQrCodeService {
 
-    private static final String URL = "http://api.qrserver.com/v1/create-qr-code/?data=https://thankoo.co.kr/code={0}&size=300x300";
+    private static final String URL = "http://api.qrserver.com/v1/create-qr-code/?data=https://thankoo.co.kr?code={0}&size=300x300";
 
     public List<AdminLinkResponse> getLinks(final AdminSerialRequest adminSerialRequest) {
         return adminSerialRequest.getSerials().stream()

--- a/backend/src/main/java/com/woowacourse/thankoo/admin/qrcode/application/AdminQrCodeService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/admin/qrcode/application/AdminQrCodeService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 public class AdminQrCodeService {
 
     private static final String URL = "http://api.qrserver.com/v1/create-qr-code/?data=https://thankoo.co.kr?code={0}&size=300x300";

--- a/backend/src/main/java/com/woowacourse/thankoo/admin/serial/application/AdminCouponSerialQueryService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/admin/serial/application/AdminCouponSerialQueryService.java
@@ -19,15 +19,7 @@ public class AdminCouponSerialQueryService {
     public List<AdminCouponSerialResponse> getByMemberId(final Long memberId) {
         List<CouponSerialMember> couponSerialMembers = couponSerialQueryRepository.findByMemberId(memberId);
         return couponSerialMembers.stream()
-                .map(AdminCouponSerialQueryService::toCouponSerialResponse)
+                .map(AdminCouponSerialResponse::from)
                 .collect(Collectors.toList());
-    }
-
-    private static AdminCouponSerialResponse toCouponSerialResponse(final CouponSerialMember couponSerial) {
-        return new AdminCouponSerialResponse(couponSerial.getId(),
-                couponSerial.getCode().getValue(),
-                couponSerial.getSenderId(),
-                couponSerial.getSenderName(),
-                couponSerial.getCouponType().getValue());
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/member/domain/MemberQueryRepository.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/domain/MemberQueryRepository.java
@@ -1,0 +1,23 @@
+package com.woowacourse.thankoo.member.domain;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public boolean existsById(final Long id) {
+        String sql = "SELECT EXISTS(SELECT 1 FROM member WHERE id = :{id})";
+
+        SqlParameterSource sqlParameterSource = new MapSqlParameterSource("id", id);
+
+        int count = jdbcTemplate.queryForObject(sql, sqlParameterSource, Integer.class);
+        return count > 0;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/thankoo/serial/application/CouponSerialQueryService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/serial/application/CouponSerialQueryService.java
@@ -1,10 +1,12 @@
 package com.woowacourse.thankoo.serial.application;
 
-import com.woowacourse.thankoo.admin.serial.presentation.dto.AdminCouponSerialResponse;
 import com.woowacourse.thankoo.common.exception.ErrorType;
+import com.woowacourse.thankoo.member.domain.MemberQueryRepository;
+import com.woowacourse.thankoo.member.exception.InvalidMemberException;
 import com.woowacourse.thankoo.serial.domain.CouponSerialMember;
 import com.woowacourse.thankoo.serial.domain.CouponSerialQueryRepository;
 import com.woowacourse.thankoo.serial.exeption.InvalidCouponSerialException;
+import com.woowacourse.thankoo.serial.presentation.dto.CouponSerialResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,10 +17,21 @@ import org.springframework.transaction.annotation.Transactional;
 public class CouponSerialQueryService {
 
     private final CouponSerialQueryRepository couponSerialQueryRepository;
+    private final MemberQueryRepository memberQueryRepository;
 
-    public AdminCouponSerialResponse getByCode(final String code) {
-        CouponSerialMember couponSerialMember = couponSerialQueryRepository.findByCode(code)
+    public CouponSerialResponse getByCode(final Long memberId, final String code) {
+        validateExistedMember(memberId);
+        return CouponSerialResponse.from(getCouponSerialMember(code));
+    }
+
+    private void validateExistedMember(final Long memberId) {
+        if (!memberQueryRepository.existsById(memberId)) {
+            throw new InvalidMemberException(ErrorType.NOT_FOUND_MEMBER);
+        }
+    }
+
+    private CouponSerialMember getCouponSerialMember(final String code) {
+        return couponSerialQueryRepository.findByCode(code)
                 .orElseThrow(() -> new InvalidCouponSerialException(ErrorType.NOT_FOUND_COUPON_SERIAL));
-        return AdminCouponSerialResponse.from(couponSerialMember);
     }
 }

--- a/backend/src/main/java/com/woowacourse/thankoo/serial/application/CouponSerialQueryService.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/serial/application/CouponSerialQueryService.java
@@ -19,7 +19,7 @@ public class CouponSerialQueryService {
     private final CouponSerialQueryRepository couponSerialQueryRepository;
     private final MemberQueryRepository memberQueryRepository;
 
-    public CouponSerialResponse getByCode(final Long memberId, final String code) {
+    public CouponSerialResponse getCouponSerialByCode(final Long memberId, final String code) {
         validateExistedMember(memberId);
         return CouponSerialResponse.from(getCouponSerialMember(code));
     }

--- a/backend/src/main/java/com/woowacourse/thankoo/serial/domain/CouponSerial.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/serial/domain/CouponSerial.java
@@ -31,11 +31,11 @@ public class CouponSerial extends BaseEntity {
     @Column(name = "sender_id", nullable = false)
     private Long senderId;
 
-    @Column(name = "coupon_type", nullable = false)
+    @Column(name = "coupon_type", nullable = false, length = 20)
     @Enumerated(value = EnumType.STRING)
     private CouponSerialType couponSerialType;
 
-    @Column(name = "status", nullable = false)
+    @Column(name = "status", nullable = false, length = 20)
     @Enumerated(value = EnumType.STRING)
     private CouponSerialStatus status;
 

--- a/backend/src/main/java/com/woowacourse/thankoo/serial/domain/SerialCode.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/serial/domain/SerialCode.java
@@ -16,7 +16,7 @@ public class SerialCode {
 
     private static final int CODE_LENGTH = 8;
 
-    @Column(name = "code", nullable = false)
+    @Column(name = "code", length = 50, nullable = false, unique = true)
     private String value;
 
     public SerialCode(final String value) {

--- a/backend/src/main/java/com/woowacourse/thankoo/serial/presentation/CouponSerialController.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/serial/presentation/CouponSerialController.java
@@ -1,13 +1,17 @@
 package com.woowacourse.thankoo.serial.presentation;
 
 import com.woowacourse.thankoo.authentication.presentation.AuthenticationPrincipal;
+import com.woowacourse.thankoo.serial.application.CouponSerialQueryService;
 import com.woowacourse.thankoo.serial.application.CouponSerialService;
 import com.woowacourse.thankoo.serial.application.dto.CouponSerialRequest;
+import com.woowacourse.thankoo.serial.presentation.dto.CouponSerialResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -15,7 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/coupon-serials")
 public class CouponSerialController {
 
+    private final CouponSerialQueryService couponSerialQueryService;
     private final CouponSerialService couponSerialService;
+
+    @GetMapping
+    public ResponseEntity<CouponSerialResponse> getCouponSerialBySerialCode(
+            @AuthenticationPrincipal final Long memberId,
+            @RequestParam final String code) {
+        return ResponseEntity.ok(couponSerialQueryService.getByCode(memberId, code));
+    }
 
     @PostMapping
     public ResponseEntity<Void> createCouponWithSerialCode(@AuthenticationPrincipal final Long memberId,

--- a/backend/src/main/java/com/woowacourse/thankoo/serial/presentation/CouponSerialController.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/serial/presentation/CouponSerialController.java
@@ -26,7 +26,7 @@ public class CouponSerialController {
     public ResponseEntity<CouponSerialResponse> getCouponSerialBySerialCode(
             @AuthenticationPrincipal final Long memberId,
             @RequestParam final String code) {
-        return ResponseEntity.ok(couponSerialQueryService.getByCode(memberId, code));
+        return ResponseEntity.ok(couponSerialQueryService.getCouponSerialByCode(memberId, code));
     }
 
     @PostMapping

--- a/backend/src/main/java/com/woowacourse/thankoo/serial/presentation/dto/CouponSerialResponse.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/serial/presentation/dto/CouponSerialResponse.java
@@ -1,0 +1,40 @@
+package com.woowacourse.thankoo.serial.presentation.dto;
+
+import com.woowacourse.thankoo.serial.domain.CouponSerialMember;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class CouponSerialResponse {
+
+    private Long id;
+    private Long senderId;
+    private String senderName;
+    private String couponType;
+
+    public CouponSerialResponse(final Long id, final Long senderId, final String senderName, final String couponType) {
+        this.id = id;
+        this.senderId = senderId;
+        this.senderName = senderName;
+        this.couponType = couponType;
+    }
+
+    public static CouponSerialResponse from(final CouponSerialMember couponSerialMember) {
+        return new CouponSerialResponse(couponSerialMember.getId(),
+                couponSerialMember.getSenderId(),
+                couponSerialMember.getSenderName(),
+                couponSerialMember.getCouponType().getValue());
+    }
+
+    @Override
+    public String toString() {
+        return "CouponSerialResponse{" +
+                "id=" + id +
+                ", senderId=" + senderId +
+                ", senderName='" + senderName + '\'' +
+                ", couponType='" + couponType + '\'' +
+                '}';
+    }
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/acceptance/CouponSerialAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/acceptance/CouponSerialAcceptanceTest.java
@@ -31,57 +31,47 @@ class CouponSerialAcceptanceTest extends AcceptanceTest {
         @Autowired
         private CouponSerialRepository couponSerialRepository;
 
-        @DisplayName("시리얼 번호를 조회할 때 ")
-        @Nested
-        class GetCouponWithSerial {
+        @DisplayName("시리얼 번호를 조회할 때 번호가 존재하면 조회한다.")
+        @Test
+        void createCoupon() {
+            TokenResponse memberToken = AuthenticationAssured.request()
+                    .회원가입_한다(SKRR_TOKEN, SKRR_NAME)
+                    .로그인_한다(CODE_SKRR)
+                    .token();
 
-            @DisplayName("번호가 존재하면 조회한다.")
-            @Test
-            void createCoupon() {
-                TokenResponse memberToken = AuthenticationAssured.request()
-                        .회원가입_한다(SKRR_TOKEN, SKRR_NAME)
-                        .로그인_한다(CODE_SKRR)
-                        .token();
+            Long senderId = AuthenticationAssured.request()
+                    .회원가입_한다(SKRR_TOKEN, SKRR_NAME)
+                    .token()
+                    .getMemberId();
 
-                Long senderId = AuthenticationAssured.request()
-                        .회원가입_한다(SKRR_TOKEN, SKRR_NAME)
-                        .token()
-                        .getMemberId();
+            쿠폰_시리얼을_생성한다(senderId, SERIAL_1);
 
-                쿠폰_시리얼을_생성한다(senderId, SERIAL_1);
-
-                CouponSerialAssured.request()
-                        .쿠폰_시리얼을_조회한다(memberToken.getAccessToken(), SERIAL_1)
-                        .response()
-                        .status(HttpStatus.OK.value())
-                        .단건_시리얼_쿠폰이_조회됨();
-            }
+            CouponSerialAssured.request()
+                    .쿠폰_시리얼을_조회한다(memberToken.getAccessToken(), SERIAL_1)
+                    .response()
+                    .status(HttpStatus.OK.value())
+                    .단건_시리얼_쿠폰이_조회됨();
         }
 
-        @DisplayName("시리얼 번호를 사용할 때 ")
-        @Nested
-        class CreateCouponWithSerial {
+        @DisplayName("시리얼 번호를 사용할 때 시리얼이 유효하면 시리얼을 사용하고 쿠폰을 생성한다.")
+        @Test
+        void userSerialCoupon() {
+            TokenResponse memberToken = AuthenticationAssured.request()
+                    .회원가입_한다(SKRR_TOKEN, SKRR_NAME)
+                    .로그인_한다(CODE_SKRR)
+                    .token();
 
-            @DisplayName("시리얼이 유효하면 시리얼을 사용하고 쿠폰을 생성한다.")
-            @Test
-            void userSerialCoupon() {
-                TokenResponse memberToken = AuthenticationAssured.request()
-                        .회원가입_한다(SKRR_TOKEN, SKRR_NAME)
-                        .로그인_한다(CODE_SKRR)
-                        .token();
+            Long senderId = AuthenticationAssured.request()
+                    .회원가입_한다(SKRR_TOKEN, SKRR_NAME)
+                    .token()
+                    .getMemberId();
 
-                Long senderId = AuthenticationAssured.request()
-                        .회원가입_한다(SKRR_TOKEN, SKRR_NAME)
-                        .token()
-                        .getMemberId();
+            쿠폰_시리얼을_생성한다(senderId, SERIAL_1);
 
-                쿠폰_시리얼을_생성한다(senderId, SERIAL_1);
-
-                CouponSerialAssured.request()
-                        .쿠폰_시리얼을_사용한다(memberToken.getAccessToken(), 쿠폰_시리얼_요청(SERIAL_1))
-                        .response()
-                        .status(HttpStatus.OK.value());
-            }
+            CouponSerialAssured.request()
+                    .쿠폰_시리얼을_사용한다(memberToken.getAccessToken(), 쿠폰_시리얼_요청(SERIAL_1))
+                    .response()
+                    .status(HttpStatus.OK.value());
         }
 
         private CouponSerial 쿠폰_시리얼을_생성한다(Long memberId, String code) {
@@ -90,3 +80,4 @@ class CouponSerialAcceptanceTest extends AcceptanceTest {
         }
     }
 }
+

--- a/backend/src/test/java/com/woowacourse/thankoo/acceptance/CouponSerialAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/acceptance/CouponSerialAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.thankoo.acceptance;
 
+import static com.woowacourse.thankoo.acceptance.builder.CouponSerialAssured.쿠폰_시리얼_요청;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
 import static com.woowacourse.thankoo.common.fixtures.OAuthFixture.CODE_SKRR;
 import static com.woowacourse.thankoo.common.fixtures.OAuthFixture.SKRR_TOKEN;
@@ -10,12 +11,10 @@ import static com.woowacourse.thankoo.serial.domain.CouponSerialStatus.NOT_USED;
 import static com.woowacourse.thankoo.serial.domain.CouponSerialType.COFFEE;
 
 import com.woowacourse.thankoo.acceptance.builder.AuthenticationAssured;
-import com.woowacourse.thankoo.acceptance.builder.CouponAssured;
+import com.woowacourse.thankoo.acceptance.builder.CouponSerialAssured;
 import com.woowacourse.thankoo.authentication.presentation.dto.TokenResponse;
-import com.woowacourse.thankoo.serial.application.dto.CouponSerialRequest;
 import com.woowacourse.thankoo.serial.domain.CouponSerial;
 import com.woowacourse.thankoo.serial.domain.CouponSerialRepository;
-import com.woowacourse.thankoo.serial.domain.SerialCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,14 +28,14 @@ class CouponSerialAcceptanceTest extends AcceptanceTest {
     @Nested
     class SignInAndTest {
 
-        @DisplayName("시리얼 번호를 요청할 때 ")
+        @Autowired
+        private CouponSerialRepository couponSerialRepository;
+
+        @DisplayName("시리얼 번호를 조회할 때 ")
         @Nested
-        class CreateCouponWithSerial {
+        class GetCouponWithSerial {
 
-            @Autowired
-            private CouponSerialRepository couponSerialRepository;
-
-            @DisplayName("시리얼이 유효하면 쿠폰을 생성한다.")
+            @DisplayName("번호가 존재하면 조회한다.")
             @Test
             void createCoupon() {
                 TokenResponse memberToken = AuthenticationAssured.request()
@@ -49,19 +48,45 @@ class CouponSerialAcceptanceTest extends AcceptanceTest {
                         .token()
                         .getMemberId();
 
-                CouponSerial couponSerial = 쿠폰_시리얼을_생성한다(senderId, SERIAL_1);
+                쿠폰_시리얼을_생성한다(senderId, SERIAL_1);
 
-                SerialCode serialCode = couponSerial.getSerialCode();
-                CouponAssured.request()
-                        .쿠폰_시리얼을_요청한다(memberToken.getAccessToken(), new CouponSerialRequest(serialCode.getValue()))
+                CouponSerialAssured.request()
+                        .쿠폰_시리얼을_조회한다(memberToken.getAccessToken(), SERIAL_1)
+                        .response()
+                        .status(HttpStatus.OK.value())
+                        .단건_시리얼_쿠폰이_조회됨();
+            }
+        }
+
+        @DisplayName("시리얼 번호를 사용할 때 ")
+        @Nested
+        class CreateCouponWithSerial {
+
+            @DisplayName("시리얼이 유효하면 시리얼을 사용하고 쿠폰을 생성한다.")
+            @Test
+            void userSerialCoupon() {
+                TokenResponse memberToken = AuthenticationAssured.request()
+                        .회원가입_한다(SKRR_TOKEN, SKRR_NAME)
+                        .로그인_한다(CODE_SKRR)
+                        .token();
+
+                Long senderId = AuthenticationAssured.request()
+                        .회원가입_한다(SKRR_TOKEN, SKRR_NAME)
+                        .token()
+                        .getMemberId();
+
+                쿠폰_시리얼을_생성한다(senderId, SERIAL_1);
+
+                CouponSerialAssured.request()
+                        .쿠폰_시리얼을_사용한다(memberToken.getAccessToken(), 쿠폰_시리얼_요청(SERIAL_1))
                         .response()
                         .status(HttpStatus.OK.value());
             }
+        }
 
-            private CouponSerial 쿠폰_시리얼을_생성한다(Long memberId, String code) {
-                return couponSerialRepository
-                        .save(new CouponSerial(code, memberId, COFFEE, NOT_USED, NEO_TITLE, NEO_MESSAGE));
-            }
+        private CouponSerial 쿠폰_시리얼을_생성한다(Long memberId, String code) {
+            return couponSerialRepository
+                    .save(new CouponSerial(code, memberId, COFFEE, NOT_USED, NEO_TITLE, NEO_MESSAGE));
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/acceptance/builder/CouponAssured.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/acceptance/builder/CouponAssured.java
@@ -12,7 +12,6 @@ import com.woowacourse.thankoo.acceptance.builder.common.RequestBuilder;
 import com.woowacourse.thankoo.acceptance.builder.common.ResponseBuilder;
 import com.woowacourse.thankoo.coupon.application.dto.ContentRequest;
 import com.woowacourse.thankoo.coupon.application.dto.CouponRequest;
-import com.woowacourse.thankoo.serial.application.dto.CouponSerialRequest;
 import com.woowacourse.thankoo.coupon.presentation.dto.CouponDetailResponse;
 import com.woowacourse.thankoo.coupon.presentation.dto.CouponResponse;
 import com.woowacourse.thankoo.coupon.presentation.dto.CouponTotalResponse;
@@ -72,11 +71,6 @@ public class CouponAssured {
 
         public CouponRequestBuilder 주고_받은_쿠폰_개수를_조회한다(final String accessToken) {
             response = getWithToken("/api/coupons/count", accessToken);
-            return this;
-        }
-
-        public CouponRequestBuilder 쿠폰_시리얼을_요청한다(final String accessToken, final CouponSerialRequest request) {
-            response = postWithToken("/api/coupon-serials", accessToken, request);
             return this;
         }
 

--- a/backend/src/test/java/com/woowacourse/thankoo/acceptance/builder/CouponSerialAssured.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/acceptance/builder/CouponSerialAssured.java
@@ -1,0 +1,68 @@
+package com.woowacourse.thankoo.acceptance.builder;
+
+import static com.woowacourse.thankoo.acceptance.support.fixtures.RestAssuredRequestFixture.getWithToken;
+import static com.woowacourse.thankoo.acceptance.support.fixtures.RestAssuredRequestFixture.postWithToken;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.woowacourse.thankoo.acceptance.builder.common.RequestBuilder;
+import com.woowacourse.thankoo.acceptance.builder.common.ResponseBuilder;
+import com.woowacourse.thankoo.serial.application.dto.CouponSerialRequest;
+import com.woowacourse.thankoo.serial.presentation.dto.CouponSerialResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+public class CouponSerialAssured {
+
+    private CouponSerialAssured() {
+    }
+
+    public static CouponSerialRequest 쿠폰_시리얼_요청(final String serialCode) {
+        return new CouponSerialRequest(serialCode);
+    }
+
+    public static CouponSerialRequestBuilder request() {
+        return new CouponSerialRequestBuilder();
+    }
+
+    public static class CouponSerialRequestBuilder extends RequestBuilder {
+
+        public CouponSerialAssured.CouponSerialRequestBuilder 쿠폰_시리얼을_조회한다(final String accessToken,
+                                                                           final String serialCode) {
+            response = getWithToken("/api/coupon-serials?code=" + serialCode, accessToken);
+            return this;
+        }
+
+        public CouponSerialAssured.CouponSerialRequestBuilder 쿠폰_시리얼을_사용한다(final String accessToken,
+                                                                           final CouponSerialRequest request) {
+            response = postWithToken("/api/coupon-serials", accessToken, request);
+            return this;
+        }
+
+        public CouponSerialResponseBuilder response() {
+            return new CouponSerialResponseBuilder(response);
+        }
+    }
+
+    public static class CouponSerialResponseBuilder extends ResponseBuilder {
+
+        public CouponSerialResponseBuilder(final ExtractableResponse<Response> response) {
+            super(response);
+        }
+
+        public CouponSerialAssured.CouponSerialResponseBuilder status(final int code) {
+            assertThat(response.statusCode()).isEqualTo(code);
+            return this;
+        }
+
+        public void 단건_시리얼_쿠폰이_조회됨() {
+            CouponSerialResponse couponSerialResponse = body(CouponSerialResponse.class);
+            assertAll(
+                    () -> assertThat(couponSerialResponse.getId()).isNotNull(),
+                    () -> assertThat(couponSerialResponse.getSenderId()).isNotNull(),
+                    () -> assertThat(couponSerialResponse.getSenderName()).isNotNull(),
+                    () -> assertThat(couponSerialResponse.getCouponType()).isNotNull()
+            );
+        }
+    }
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/member/domain/MemberQueryRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/domain/MemberQueryRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.woowacourse.thankoo.member.domain;
+
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_SOCIAL_ID;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_IMAGE_URL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.thankoo.common.annotations.RepositoryTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+@DisplayName("MemberQueryRepository 는 ")
+@RepositoryTest
+class MemberQueryRepositoryTest {
+
+    private MemberQueryRepository memberQueryRepository;
+
+    @Autowired
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        memberQueryRepository = new MemberQueryRepository(jdbcTemplate);
+    }
+
+    @DisplayName("회원이 존재하는지 확인할 때")
+    @Nested
+    class ExistedMember {
+
+        @DisplayName("존재하면 true를 반환한다.")
+        @Test
+        void existedById() {
+            Member member = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, HUNI_IMAGE_URL));
+
+            assertThat(memberQueryRepository.existsById(member.getId())).isTrue();
+        }
+
+        @DisplayName("존재하지 않으면 false를 반환한다.")
+        @Test
+        void notExistedById() {
+            assertThat(memberQueryRepository.existsById(0L)).isFalse();
+        }
+    }
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/serial/application/CouponSerialQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/serial/application/CouponSerialQueryServiceTest.java
@@ -13,13 +13,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.woowacourse.thankoo.admin.serial.presentation.dto.AdminCouponSerialResponse;
 import com.woowacourse.thankoo.common.annotations.ApplicationTest;
 import com.woowacourse.thankoo.member.domain.Member;
 import com.woowacourse.thankoo.member.domain.MemberRepository;
+import com.woowacourse.thankoo.member.exception.InvalidMemberException;
 import com.woowacourse.thankoo.serial.domain.CouponSerial;
 import com.woowacourse.thankoo.serial.domain.CouponSerialRepository;
 import com.woowacourse.thankoo.serial.exeption.InvalidCouponSerialException;
+import com.woowacourse.thankoo.serial.presentation.dto.CouponSerialResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -50,20 +51,33 @@ class CouponSerialQueryServiceTest {
             couponSerialRepository.save(
                     new CouponSerial(SERIAL_1, member.getId(), COFFEE, NOT_USED, NEO_TITLE, NEO_MESSAGE));
 
-            AdminCouponSerialResponse response = couponSerialQueryService.getByCode(SERIAL_1);
+            CouponSerialResponse response = couponSerialQueryService.getByCode(member.getId(), SERIAL_1);
 
             assertAll(
                     () -> assertThat(response.getCouponType()).isEqualTo("COFFEE"),
-                    () -> assertThat(response.getSenderName()).isEqualTo(NEO_NAME)
+                    () -> assertThat(response.getSenderName()).isEqualTo(NEO_NAME),
+                    () -> assertThat(response.getSenderId()).isEqualTo(member.getId())
             );
         }
 
-        @DisplayName("존재하지 않는 경우 예외를 발생한다.")
+        @DisplayName("시리얼 코드가 존재하지 않는 경우 예외를 발생한다.")
         @Test
-        void getCouponSerialByNotExistsCode() {
-            assertThatThrownBy(() -> couponSerialQueryService.getByCode(SERIAL_1))
+        void getCouponSerialByNotExistsSerialCode() {
+            Member member = memberRepository.save(new Member(NEO_NAME, NEO_EMAIL, NEO_SOCIAL_ID, HUNI_IMAGE_URL));
+
+            assertThatThrownBy(() -> couponSerialQueryService.getByCode(member.getId(), SERIAL_1))
                     .isInstanceOf(InvalidCouponSerialException.class)
                     .hasMessage("존재하지 않는 쿠폰 시리얼 번호입니다.");
+        }
+
+        @DisplayName("회원이 존재하지 않는 경우 예외를 발생한다.")
+        @Test
+        void getCouponSerialByNotExistsMember() {
+            couponSerialRepository.save(new CouponSerial(SERIAL_1, 1L, COFFEE, NOT_USED, NEO_TITLE, NEO_MESSAGE));
+
+            assertThatThrownBy(() -> couponSerialQueryService.getByCode(1L, SERIAL_1))
+                    .isInstanceOf(InvalidMemberException.class)
+                    .hasMessage("존재하지 않는 회원입니다.");
         }
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/serial/application/CouponSerialQueryServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/serial/application/CouponSerialQueryServiceTest.java
@@ -51,7 +51,7 @@ class CouponSerialQueryServiceTest {
             couponSerialRepository.save(
                     new CouponSerial(SERIAL_1, member.getId(), COFFEE, NOT_USED, NEO_TITLE, NEO_MESSAGE));
 
-            CouponSerialResponse response = couponSerialQueryService.getByCode(member.getId(), SERIAL_1);
+            CouponSerialResponse response = couponSerialQueryService.getCouponSerialByCode(member.getId(), SERIAL_1);
 
             assertAll(
                     () -> assertThat(response.getCouponType()).isEqualTo("COFFEE"),
@@ -65,7 +65,7 @@ class CouponSerialQueryServiceTest {
         void getCouponSerialByNotExistsSerialCode() {
             Member member = memberRepository.save(new Member(NEO_NAME, NEO_EMAIL, NEO_SOCIAL_ID, HUNI_IMAGE_URL));
 
-            assertThatThrownBy(() -> couponSerialQueryService.getByCode(member.getId(), SERIAL_1))
+            assertThatThrownBy(() -> couponSerialQueryService.getCouponSerialByCode(member.getId(), SERIAL_1))
                     .isInstanceOf(InvalidCouponSerialException.class)
                     .hasMessage("존재하지 않는 쿠폰 시리얼 번호입니다.");
         }
@@ -75,7 +75,7 @@ class CouponSerialQueryServiceTest {
         void getCouponSerialByNotExistsMember() {
             couponSerialRepository.save(new CouponSerial(SERIAL_1, 1L, COFFEE, NOT_USED, NEO_TITLE, NEO_MESSAGE));
 
-            assertThatThrownBy(() -> couponSerialQueryService.getByCode(1L, SERIAL_1))
+            assertThatThrownBy(() -> couponSerialQueryService.getCouponSerialByCode(1L, SERIAL_1))
                     .isInstanceOf(InvalidMemberException.class)
                     .hasMessage("존재하지 않는 회원입니다.");
         }

--- a/backend/src/test/java/com/woowacourse/thankoo/serial/presentation/CouponSerialControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/serial/presentation/CouponSerialControllerTest.java
@@ -39,7 +39,7 @@ class CouponSerialControllerTest extends ControllerTest {
         given(jwtTokenProvider.getPayload(anyString()))
                 .willReturn("1");
 
-        given(couponSerialQueryService.getByCode(anyLong(), anyString()))
+        given(couponSerialQueryService.getCouponSerialByCode(anyLong(), anyString()))
                 .willReturn(new CouponSerialResponse(1L, 2L, NEO_NAME, CouponType.COFFEE.getValue()));
 
         ResultActions resultActions = mockMvc.perform(get("/api/coupon-serials")

--- a/backend/src/test/java/com/woowacourse/thankoo/serial/presentation/CouponSerialControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/serial/presentation/CouponSerialControllerTest.java
@@ -1,23 +1,29 @@
 package com.woowacourse.thankoo.serial.presentation;
 
-import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_NAME;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.NEO_NAME;
 import static com.woowacourse.thankoo.common.fixtures.SerialFixture.SERIAL_1;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.woowacourse.thankoo.admin.serial.presentation.dto.AdminCouponSerialResponse;
 import com.woowacourse.thankoo.common.ControllerTest;
-import com.woowacourse.thankoo.serial.application.dto.CouponSerialRequest;
 import com.woowacourse.thankoo.coupon.domain.CouponType;
+import com.woowacourse.thankoo.serial.application.dto.CouponSerialRequest;
+import com.woowacourse.thankoo.serial.presentation.dto.CouponSerialResponse;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,16 +33,48 @@ import org.springframework.test.web.servlet.ResultActions;
 @DisplayName("CouponSerialController 는 ")
 class CouponSerialControllerTest extends ControllerTest {
 
-    @DisplayName("쿠폰 시리얼로 쿠폰을 생성한다.")
+    @DisplayName("시리얼 코드로 쿠폰 시리얼을 조회한다.")
+    @Test
+    void getCouponSerial() throws Exception {
+        given(jwtTokenProvider.getPayload(anyString()))
+                .willReturn("1");
+
+        given(couponSerialQueryService.getByCode(anyLong(), anyString()))
+                .willReturn(new CouponSerialResponse(1L, 2L, NEO_NAME, CouponType.COFFEE.getValue()));
+
+        ResultActions resultActions = mockMvc.perform(get("/api/coupon-serials")
+                        .param("code", SERIAL_1)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        resultActions.andDo(document("coupons/get-serial",
+                getRequestPreprocessor(),
+                getResponsePreprocessor(),
+                requestHeaders(
+                        headerWithName(HttpHeaders.AUTHORIZATION).description("token")
+                ),
+                requestParameters(
+                        parameterWithName("code").description("serial code")
+                ),
+                responseFields(
+                        fieldWithPath("id").type(NUMBER).description("id"),
+                        fieldWithPath("senderId").type(NUMBER).description("sender id"),
+                        fieldWithPath("senderName").type(STRING).description("sender name"),
+                        fieldWithPath("couponType").type(STRING).description("coupon type")
+                )
+        ));
+    }
+
+    @DisplayName("쿠폰 시리얼을 사용한다.")
     @Test
     void createCouponWithSerial() throws Exception {
         given(jwtTokenProvider.getPayload(anyString()))
                 .willReturn("1");
 
         CouponSerialRequest request = new CouponSerialRequest(SERIAL_1);
-        given(couponSerialQueryService.getByCode(anyString()))
-                .willReturn(new AdminCouponSerialResponse(1L, request.getSerialCode(), 1L, HUNI_NAME,
-                        CouponType.COFFEE.getValue()));
 
         ResultActions resultActions = mockMvc.perform(post("/api/coupon-serials")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")


### PR DESCRIPTION
## 상세 내용
- code 로 쿠폰 시리얼을 조회합니다.

엔티티에 unique 조건과 길이를 조절했어요.

특이사항으로는 쿠폰을 조회할 때 memberId를 받아오는데 존재하는 회원인지 확인하기 위해 jpa의 `existsById()`를 사용했는데 `limit` 조건이 안붙더라구요. 그래서 아예 Jdbc를 사용해서 `exists` 쿼리를 사용하도록 수정했어요.

Close #433 

