### PR TITLE
fix: 승낙, 거절 후 로컬 스토리지 query 삭제

### DIFF
--- a/frontend/src/components/Main/QRCouponRegisterModal.tsx
+++ b/frontend/src/components/Main/QRCouponRegisterModal.tsx
@@ -34,17 +34,20 @@ const QRCouponRegisterModal = ({
         data: { serialCode },
       }),
     {
-      onSuccess: () => {
+      onMutate: () => {
         close();
+      },
+      onSuccess: () => {
+        localStorage.removeItem('query');
         insertToastItem('등록이 완료됐습니다!');
-        navigate(ROUTE_PATH.EXACT_MAIN);
         queryClient.invalidateQueries([COUPON_QUERY_KEY.coupon]);
+        navigate(ROUTE_PATH.EXACT_MAIN);
       },
       onError: (error: AxiosError<ErrorType>) => {
+        localStorage.removeItem('query');
         alert(error.response?.data.message);
-        close();
-        navigate(ROUTE_PATH.EXACT_MAIN);
         queryClient.invalidateQueries([COUPON_QUERY_KEY.coupon]);
+        navigate(ROUTE_PATH.EXACT_MAIN);
       },
       retry: false,
     }
@@ -60,7 +63,7 @@ const QRCouponRegisterModal = ({
         </S.ContentWrapper>
         <S.ContentWrapper>
           <S.TitleText>쿠폰 종류</S.TitleText>
-          <S.ContentText>{couponTypes[QRCode.couponType]}</S.ContentText>
+          <S.ContentText>{couponTypes[QRCode.couponType.toLocaleLowerCase()]}</S.ContentText>
         </S.ContentWrapper>
         <S.ButtonWrapper>
           <S.Button
@@ -74,6 +77,7 @@ const QRCouponRegisterModal = ({
           <S.Button
             onClick={() => {
               close();
+              localStorage.removeItem('query');
               navigate(ROUTE_PATH.EXACT_MAIN);
             }}
           >


### PR DESCRIPTION
## 상세 내용
- QR 쿠폰을 등록하는 모달에서 등록 or 거절을 클릭 시 로컬 스토리지에서 query를 삭제한다.
- 그러나 아직 esc나 deemed를 클릭했을 때 로컬 스토리지를 비우고 메인 페이지로 리다이렉트하는 로직은 구현하지 못했다.

Close #471 

