### PR TITLE
fix: qr 코드 등록, 취소 후 리다이렉트가 기록이 남지 않도록 한다.

### DIFF
--- a/frontend/src/components/Main/QRCouponRegisterModal.tsx
+++ b/frontend/src/components/Main/QRCouponRegisterModal.tsx
@@ -41,13 +41,13 @@ const QRCouponRegisterModal = ({
         localStorage.removeItem('query');
         insertToastItem('등록이 완료됐습니다!');
         queryClient.invalidateQueries([COUPON_QUERY_KEY.coupon]);
-        navigate(ROUTE_PATH.EXACT_MAIN);
+        navigate(ROUTE_PATH.EXACT_MAIN, { replace: true });
       },
       onError: (error: AxiosError<ErrorType>) => {
         localStorage.removeItem('query');
         alert(error.response?.data.message);
         queryClient.invalidateQueries([COUPON_QUERY_KEY.coupon]);
-        navigate(ROUTE_PATH.EXACT_MAIN);
+        navigate(ROUTE_PATH.EXACT_MAIN, { replace: true });
       },
       retry: false,
     }
@@ -78,7 +78,7 @@ const QRCouponRegisterModal = ({
             onClick={() => {
               close();
               localStorage.removeItem('query');
-              navigate(ROUTE_PATH.EXACT_MAIN);
+              navigate(ROUTE_PATH.EXACT_MAIN, { replace: true });
             }}
           >
             취소

--- a/frontend/src/hooks/useQRCoupon.tsx
+++ b/frontend/src/hooks/useQRCoupon.tsx
@@ -41,7 +41,7 @@ const useQRCoupon = () => {
       },
       onError: () => {
         alert('등록되지 않은 쿠폰입니다.');
-        navigate(ROUTE_PATH.EXACT_MAIN);
+        navigate(ROUTE_PATH.EXACT_MAIN, { replace: true });
       },
       retry: false,
       enabled: !!code,


### PR DESCRIPTION
## 상세 내용
- navigate에 replace:true 옵션을 넣어서 navigate 시 히스토리가 쌓이지 않도록 한다.

Close #475 
