### PR TITLE
fix: main 페이지 하단에 짤리는 부분이 없도록 한다.

### DIFF
--- a/frontend/src/components/@shared/Layout/PageLayout.tsx
+++ b/frontend/src/components/@shared/Layout/PageLayout.tsx
@@ -4,7 +4,7 @@ const PageLayout = styled.div`
   display: flex;
   flex-direction: column;
   padding: 0 0.5rem;
-  max-width: 68rem;
+  max-width: 55rem;
   margin: 0 auto;
   height: 100%;
   position: relative;

--- a/frontend/src/components/Main/GridViewCoupons.tsx
+++ b/frontend/src/components/Main/GridViewCoupons.tsx
@@ -45,12 +45,10 @@ const S = {
     grid-template-columns: repeat(auto-fill, minmax(145px, 150px));
     gap: 30px 15px;
 
-    height: fit-content;
-    max-height: calc(100% - 4.7rem);
-
     place-items: center;
     justify-content: space-around;
     overflow-y: auto;
+    padding-bottom: 15rem;
 
     &::-webkit-scrollbar {
       width: 2px;

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -155,8 +155,7 @@ const S = {
   TabsNavWrapper: styled.div`
     display: flex;
     justify-content: space-between;
-    height: 3.2rem;
-    margin-bottom: 1.5rem;
+    margin-bottom: 2.5rem;
   `,
   UsedCouponToggleForm: styled.form`
     display: flex;

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -107,7 +107,7 @@ const S = {
   Body: styled.div`
     display: flex;
     flex-direction: column;
-    height: calc(79.5% - 5.5rem);
+    overflow: auto;
   `,
   CouponStatusNavWrapper: styled.div`
     position: relative;


### PR DESCRIPTION
## 상세 내용
- GridViewCoupons에 padding-bottom을 줘서 짤리는 부분이 없도록 했다.
- 공통 Layout의 width가 커진 것 같아서 조금 줄였습니다.

## 구현 화면
**AS-IS**
<img width="350" alt="image" src="https://user-images.githubusercontent.com/41886825/193756910-72a6b328-d32f-4aa4-9878-c77dcc9fc028.png">

**TO-BE**
<img width="350" alt="image" src="https://user-images.githubusercontent.com/41886825/193759436-33ffb65a-4c31-42b8-a821-e5c1f39f5a31.png">


Close #506 

