### PR TITLE
refactor: 회원 관련 테스트 추가 및 리팩토링을 한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/common/exception/ErrorType.java
@@ -19,6 +19,7 @@ public enum ErrorType {
     INVALID_MEMBER_EMAIL(2003, "올바르지 않은 이메일 형식입니다."),
     INVALID_MEMBER(2004, "올바르지 않은 회원입니다."),
     INVALID_MEMBER_PROFILE_IMAGE(2005, "올바르지 않은 프로필 이미지입니다."),
+    INVALID_MEMBER_SOCIAL_ID(2006, "올바르지 않은 소셜 id 입니다."),
 
     INVALID_COUPON_TYPE(3001, "존재하지 않는 쿠폰 타입입니다."),
     INVALID_COUPON_TITLE(3002, "잘못된 쿠폰 제목입니다."),

--- a/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/Meeting.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/meeting/domain/Meeting.java
@@ -89,7 +89,7 @@ public class Meeting extends BaseEntity {
 
     private boolean isMemberNotOwnsCoupon(final List<Member> members, final Coupon coupon) {
         return members.stream()
-                .anyMatch(member -> !member.hasSameId(List.of(coupon.getReceiverId(), coupon.getSenderId())));
+                .anyMatch(member -> !member.includesOneOfId(List.of(coupon.getReceiverId(), coupon.getSenderId())));
     }
 
     private List<MeetingMember> convertToMeetingMember(final List<Member> members) {

--- a/backend/src/main/java/com/woowacourse/thankoo/member/domain/Email.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/domain/Email.java
@@ -18,7 +18,7 @@ public class Email {
     private static final Pattern EMAIL_REGEX = Pattern.compile(
             "^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,6}$");
 
-    @Column(name = "email")
+    @Column(name = "email", nullable = false)
     private String value;
 
     public Email(final String value) {

--- a/backend/src/main/java/com/woowacourse/thankoo/member/domain/Email.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/domain/Email.java
@@ -15,7 +15,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Email {
 
-    private static final String EMAIL_REGEX_PATTERN = "^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,6}$";
+    private static final Pattern EMAIL_REGEX = Pattern.compile(
+            "^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+.[a-zA-Z]{2,6}$");
 
     @Column(name = "email")
     private String value;
@@ -26,9 +27,13 @@ public class Email {
     }
 
     private void validateEmail(final String email) {
-        if (email.isBlank() || !Pattern.matches(EMAIL_REGEX_PATTERN, email)) {
+        if (email.isBlank() || !isValidPattern(email)) {
             throw new InvalidMemberException(ErrorType.INVALID_MEMBER_EMAIL);
         }
+    }
+
+    private boolean isValidPattern(final String email) {
+        return EMAIL_REGEX.matcher(email).matches();
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/thankoo/member/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/domain/Member.java
@@ -32,13 +32,14 @@ public class Member extends BaseEntity {
     @Embedded
     private Email email;
 
-    @Column(name = "social_id")
+    @Column(name = "social_id", nullable = false)
     private String socialId;
 
-    @Column(name = "image_url", length = 2_000)
+    @Column(name = "image_url", length = 2_000, nullable = false)
     private String imageUrl;
 
     public Member(final Long id, final String name, final String email, final String socialId, final String imageUrl) {
+        validateSocialId(socialId);
         this.id = id;
         this.name = new Name(name);
         this.email = new Email(email);
@@ -48,6 +49,12 @@ public class Member extends BaseEntity {
 
     public Member(final String name, final String email, final String socialId, final String imageUrl) {
         this(null, name, email, socialId, imageUrl);
+    }
+
+    private void validateSocialId(final String socialId) {
+        if (socialId.isBlank()) {
+            throw new InvalidMemberException(ErrorType.INVALID_MEMBER_SOCIAL_ID);
+        }
     }
 
     public void updateName(final String name) {
@@ -70,7 +77,7 @@ public class Member extends BaseEntity {
                 .anyMatch(imageUrl::equals);
     }
 
-    public boolean hasSameId(final List<Long> ids) {
+    public boolean includesOneOfId(final List<Long> ids) {
         return ids.stream()
                 .anyMatch(this::isSameId);
     }

--- a/backend/src/main/java/com/woowacourse/thankoo/member/domain/Name.java
+++ b/backend/src/main/java/com/woowacourse/thankoo/member/domain/Name.java
@@ -16,7 +16,7 @@ public class Name {
 
     private static final int NAME_MAX_LENGTH = 5;
 
-    @Column(name = "name", length = 50)
+    @Column(name = "name", length = 50, nullable = false)
     private String value;
 
     public Name(String value) {

--- a/backend/src/test/java/com/woowacourse/thankoo/common/fixtures/AuthenticationFixture.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/common/fixtures/AuthenticationFixture.java
@@ -1,0 +1,9 @@
+package com.woowacourse.thankoo.common.fixtures;
+
+public class AuthenticationFixture {
+
+    public static final String ACCESS_TOKEN = "Bearer accessToken";
+
+    private AuthenticationFixture() {
+    }
+}

--- a/backend/src/test/java/com/woowacourse/thankoo/common/fixtures/MemberFixture.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/common/fixtures/MemberFixture.java
@@ -22,13 +22,12 @@ public class MemberFixture {
     public static final String HUNI_SOCIAL_ID = "4";
     public static final String NEO_SOCIAL_ID = "5";
 
-    public static final String COMMON_IMAGE_URL = "/profile-image/";
+    private static final String COMMON_IMAGE_URL = "/profile-image/";
 
-    public static final String SKRR_IMAGE_NAME = "user_skull.svg";
-    public static final String HUNI_IMAGE_NAME = "user_pig.svg";
-
-    public static final String SKRR_IMAGE_URL = COMMON_IMAGE_URL + SKRR_IMAGE_NAME;
-    public static final String HUNI_IMAGE_URL = COMMON_IMAGE_URL + HUNI_IMAGE_NAME;
+    public static final String HOHO_IMAGE_URL = COMMON_IMAGE_URL + "user_hoho.svg";
+    public static final String SKRR_IMAGE_URL = COMMON_IMAGE_URL + "user_skull.svg";
+    public static final String LALA_IMAGE_URL = COMMON_IMAGE_URL + "user_lala.svg";
+    public static final String HUNI_IMAGE_URL = COMMON_IMAGE_URL + "user_pig.svg";
 
     private MemberFixture() {
     }

--- a/backend/src/test/java/com/woowacourse/thankoo/member/application/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/application/MemberServiceTest.java
@@ -1,15 +1,16 @@
 package com.woowacourse.thankoo.member.application;
 
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_SOCIAL_ID;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_ID;
-import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_IMAGE_URL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -40,9 +41,9 @@ class MemberServiceTest {
     @DisplayName("본인을 제외한 모든 회원을 조회한다.")
     @Test
     void getMembersExcludeMe() {
-        Member member = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, SKRR_IMAGE_URL));
-        memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, SKRR_IMAGE_URL));
-        memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_EMAIL, SKRR_IMAGE_URL));
+        Member member = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, LALA_IMAGE_URL));
+        memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, HOHO_IMAGE_URL));
+        memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_EMAIL, HUNI_IMAGE_URL));
 
         List<MemberResponse> memberResponses = memberService.getMembersExcludeMe(member.getId());
 
@@ -55,25 +56,28 @@ class MemberServiceTest {
     @DisplayName("내 정보를 조회한다.")
     @Test
     void getMember() {
-        Member member = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, SKRR_IMAGE_URL));
+        Member member = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, LALA_IMAGE_URL));
 
         MemberResponse memberResponse = memberService.getMember(member.getId());
 
-        assertThat(memberResponse).usingRecursiveComparison()
-                .isEqualTo(MemberResponse.of(member));
+        assertAll(
+                () -> assertThat(memberResponse.getName()).isEqualTo(LALA_NAME),
+                () -> assertThat(memberResponse.getEmail()).isEqualTo(LALA_EMAIL),
+                () -> assertThat(memberResponse.getImageUrl()).isEqualTo(LALA_IMAGE_URL)
+        );
     }
 
-    @Nested
     @DisplayName("회원 이름을 수정할 때 ")
+    @Nested
     class UpdateNameTest {
 
         @DisplayName("회원이 존재하면 정상적으로 이름을 수정한다.")
         @Test
         void updateMemberName() {
-            Member member = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, SKRR_IMAGE_URL));
+            Member member = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, LALA_IMAGE_URL));
             memberService.updateMemberName(member.getId(), new MemberNameRequest(HUNI_NAME));
 
-            Member foundMember = memberRepository.findById(member.getId()).get();
+            Member foundMember = memberRepository.findById(member.getId()).orElseThrow();
 
             assertAll(
                     () -> assertThat(foundMember).isNotNull(),
@@ -90,17 +94,17 @@ class MemberServiceTest {
         }
     }
 
-    @Nested
     @DisplayName("회원 프로필 이미지를 수정할 때 ")
+    @Nested
     class UpdateProfileImageTest {
 
         @DisplayName("회원이 존재하면 정상적으로 프로필 이미지를 수정한다.")
         @Test
         void updateMemberName() {
-            Member member = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, SKRR_IMAGE_URL));
+            Member member = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, LALA_IMAGE_URL));
             memberService.updateMemberProfileImage(member.getId(), new MemberProfileImageRequest(HUNI_IMAGE_URL));
 
-            Member foundMember = memberRepository.findById(member.getId()).get();
+            Member foundMember = memberRepository.findById(member.getId()).orElseThrow();
 
             assertAll(
                     () -> assertThat(foundMember).isNotNull(),
@@ -121,6 +125,6 @@ class MemberServiceTest {
     @DisplayName("모든 회원 프로필 이미지들을 조회한다.")
     @Test
     void getProfileImages() {
-        assertThat(memberService.getProfileImages()).hasSize(8);
+        assertThat(memberService.getProfileImages()).hasSizeGreaterThanOrEqualTo(0);
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/member/domain/EmailTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/domain/EmailTest.java
@@ -1,10 +1,12 @@
 package com.woowacourse.thankoo.member.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.woowacourse.thankoo.member.exception.InvalidMemberException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -12,7 +14,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class EmailTest {
 
     @DisplayName("올바르지 않은 이메일 값으로 생성하면 예외가 발생한다.")
-    @ParameterizedTest
+    @ParameterizedTest(name = "email : {0}")
     @ValueSource(strings = {" ", "abcdefghijkabcdefghijk1", "abc@abc"})
     void createWithInvalidEmailException(final String value) {
         assertThatThrownBy(() -> new Email(value))
@@ -21,10 +23,18 @@ class EmailTest {
     }
 
     @DisplayName("올바른 이메일은 성공한다.")
-    @ParameterizedTest
+    @ParameterizedTest(name = "email : {0}")
     @ValueSource(strings = {"huni@huni.com", "huni@huni.co.kr", "huni_thankoo@huni.com", "huni.a@huni.com",
             "hu.ni.dev@huni.com"})
     void create(final String value) {
         assertDoesNotThrow(() -> new Email(value));
+    }
+
+    @DisplayName("동일한 이메일인지 확인한다. ")
+    @Test
+    void equals() {
+        Email email = new Email("huni@huni.com");
+
+        assertThat(email).isEqualTo(new Email("huni@huni.com"));
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/member/domain/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/domain/MemberRepositoryTest.java
@@ -1,12 +1,15 @@
 package com.woowacourse.thankoo.member.domain;
 
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_SOCIAL_ID;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_SOCIAL_ID;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.LALA_SOCIAL_ID;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_IMAGE_URL;
@@ -15,7 +18,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.thankoo.common.annotations.RepositoryTest;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,61 +29,57 @@ class MemberRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    @DisplayName("회원을 저장한다.")
-    @Test
-    void save() {
-        Member member = new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, SKRR_IMAGE_URL);
-
-        Member savedMember = memberRepository.save(member);
-
-        assertThat(savedMember).isEqualTo(member);
-    }
-
-    @DisplayName("이름 순서대로 회원을 조회한다.")
+    @DisplayName("본인을 제외하고 이름 순서대로 회원을 조회한다.")
     @Test
     void findAllByOrderByNameAsc() {
-        Member member = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, SKRR_IMAGE_URL));
-        memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL));
-        memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, SKRR_IMAGE_URL));
+        Member member = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, LALA_IMAGE_URL));
+        memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, HUNI_IMAGE_URL));
+        memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, HOHO_IMAGE_URL));
 
         List<Member> members = memberRepository.findAllByIdNotOrderByNameAsc(member.getId());
 
-        assertThat(members).extracting("name").containsExactly(new Name(HOHO_NAME), new Name(HUNI_NAME));
+        assertThat(members).extracting("name")
+                .containsExactly(new Name(HOHO_NAME), new Name(HUNI_NAME));
     }
 
-    @DisplayName("id에 해당하는 회원 개수를 조회한다.")
+    @DisplayName("id에 해당하는 회원 수를 조회한다.")
     @Test
     void countByIdIn() {
-        Member lala = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, SKRR_IMAGE_URL));
-        Member hoho = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, SKRR_IMAGE_URL));
-        Member huni = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL));
+        Member lala = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, LALA_IMAGE_URL));
+        Member hoho = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, HOHO_IMAGE_URL));
+        Member huni = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, HUNI_IMAGE_URL));
 
         long count = memberRepository.countByIdIn(List.of(lala.getId(), hoho.getId(), huni.getId()));
+
         assertThat(count).isEqualTo(3);
     }
 
     @DisplayName("소셜 아이디로 회원을 조회한다.")
     @Test
     void findBySocialId() {
-        Member member = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, SKRR_IMAGE_URL));
+        memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, HOHO_IMAGE_URL));
 
-        Optional<Member> foundMember = memberRepository.findBySocialId(HOHO_SOCIAL_ID);
+        Member member = memberRepository.findBySocialId(HOHO_SOCIAL_ID).orElseThrow();
 
         assertAll(
-                () -> assertThat(foundMember).isNotEmpty(),
-                () -> assertThat(foundMember.orElseThrow()).isEqualTo(member)
+                () -> assertThat(member.getId()).isNotNull(),
+                () -> assertThat(member.getSocialId()).isEqualTo(HOHO_SOCIAL_ID)
         );
     }
 
     @DisplayName("회원들의 id로 회원 목록을 조회한다.")
     @Test
     void findByIdIn() {
-        Member lala = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, SKRR_IMAGE_URL));
-        Member hoho = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, SKRR_IMAGE_URL));
+        Member lala = memberRepository.save(new Member(LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, LALA_IMAGE_URL));
+        Member hoho = memberRepository.save(new Member(HOHO_NAME, HOHO_EMAIL, HOHO_SOCIAL_ID, HOHO_IMAGE_URL));
         Member huni = memberRepository.save(new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL));
 
         List<Member> members = memberRepository.findByIdIn(List.of(lala.getId(), hoho.getId(), huni.getId()));
 
-        assertThat(members).hasSize(3);
+        assertAll(
+                () -> assertThat(members).hasSize(3),
+                () -> assertThat(members).extracting("name")
+                        .containsExactly(new Name(LALA_NAME), new Name(HOHO_NAME), new Name(HUNI_NAME))
+        );
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/domain/MemberTest.java
@@ -1,5 +1,8 @@
 package com.woowacourse.thankoo.member.domain;
 
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_EMAIL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_IMAGE_URL;
+import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HOHO_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_NAME;
@@ -15,43 +18,42 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("Member 는 ")
 class MemberTest {
 
-    @DisplayName("올바르지 않은 이름으로 생성하면 예외가 발생한다.")
-    @ParameterizedTest
-    @ValueSource(strings = {" ", "abcdef"})
-    void createWithInvalidNameException(String name) {
-        assertThatThrownBy(() -> new Member(name, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL))
-                .isInstanceOf(InvalidMemberException.class)
-                .hasMessage("올바르지 않은 이름입니다.");
-    }
+    @DisplayName("회원을 생성할 때")
+    @Nested
+    class Create {
 
-    @DisplayName("올바르지 않은 이메일로 생성하면 예외가 발생한다.")
-    @ParameterizedTest
-    @ValueSource(strings = {" ", "abcdefghijkabcdefghijk1", "abc@abc"})
-    void createWithInvalidEmailException(String email) {
-        assertThatThrownBy(() -> new Member(HUNI_NAME, email, HUNI_SOCIAL_ID, SKRR_IMAGE_URL))
-                .isInstanceOf(InvalidMemberException.class)
-                .hasMessage("올바르지 않은 이메일 형식입니다.");
-    }
+        @DisplayName("올바르지 않은 이름으로 생성하면 예외가 발생한다.")
+        @ParameterizedTest(name = "name : {0}")
+        @ValueSource(strings = {" ", "abcdef"})
+        void createWithInvalidNameException(String name) {
+            assertThatThrownBy(() -> new Member(name, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL))
+                    .isInstanceOf(InvalidMemberException.class)
+                    .hasMessage("올바르지 않은 이름입니다.");
+        }
 
-    @DisplayName("하나라도 같은 id가 있는지 판별한다.")
-    @Test
-    void hasSameId() {
-        Member member = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL);
+        @DisplayName("올바르지 않은 이메일로 생성하면 예외가 발생한다.")
+        @ParameterizedTest(name = "email : {0}")
+        @ValueSource(strings = {" ", "abcdefghijkabcdefghijk1", "abc@abc"})
+        void createWithInvalidEmailException(String email) {
+            assertThatThrownBy(() -> new Member(HUNI_NAME, email, HUNI_SOCIAL_ID, SKRR_IMAGE_URL))
+                    .isInstanceOf(InvalidMemberException.class)
+                    .hasMessage("올바르지 않은 이메일 형식입니다.");
+        }
 
-        assertThat(member.includeOneOfId(List.of(1L, 2L))).isTrue();
-    }
-
-    @DisplayName("동일한 id인지 판별한다.")
-    @Test
-    void isSameId() {
-        Member member = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL);
-
-        assertThat(member.isSameId(1L)).isTrue();
+        @DisplayName("소셜 id가 비어있다면 예외가 발생한다.")
+        @ParameterizedTest(name = "social id : {0}")
+        @EmptySource
+        void createWithInvalidSocialException(String socialId) {
+            assertThatThrownBy(() -> new Member(HOHO_NAME, HOHO_EMAIL, socialId, HOHO_IMAGE_URL))
+                    .isInstanceOf(InvalidMemberException.class)
+                    .hasMessage("올바르지 않은 소셜 id 입니다.");
+        }
     }
 
     @DisplayName("이름을 변경할 때 ")
@@ -101,5 +103,21 @@ class MemberTest {
                     .isInstanceOf(InvalidMemberException.class)
                     .hasMessage("올바르지 않은 프로필 이미지입니다.");
         }
+    }
+
+    @DisplayName("하나라도 같은 id가 있는지 판별한다.")
+    @Test
+    void hasSameId() {
+        Member member = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL);
+
+        assertThat(member.includesOneOfId(List.of(1L, 2L))).isTrue();
+    }
+
+    @DisplayName("동일한 id인지 판별한다.")
+    @Test
+    void isSameId() {
+        Member member = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL);
+
+        assertThat(member.isSameId(1L)).isTrue();
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/member/domain/MemberTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/domain/MemberTest.java
@@ -38,22 +38,24 @@ class MemberTest {
                 .hasMessage("올바르지 않은 이메일 형식입니다.");
     }
 
-    @DisplayName("둘 중 동일한 id를 판별한다.")
+    @DisplayName("하나라도 같은 id가 있는지 판별한다.")
     @Test
     void hasSameId() {
         Member member = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL);
-        assertThat(member.hasSameId(List.of(1L, 2L))).isTrue();
+
+        assertThat(member.includeOneOfId(List.of(1L, 2L))).isTrue();
     }
 
-    @DisplayName("동일한 id를 판별한다.")
+    @DisplayName("동일한 id인지 판별한다.")
     @Test
     void isSameId() {
         Member member = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL);
+
         assertThat(member.isSameId(1L)).isTrue();
     }
 
-    @Nested
     @DisplayName("이름을 변경할 때 ")
+    @Nested
     class UpdateNameTest {
 
         @DisplayName("정상적인 이름으로 변경하면 변경에 성공한다.")
@@ -70,19 +72,34 @@ class MemberTest {
         @ValueSource(strings = {" ", "abcdefghijkabcdefghijk1"})
         void updateBlankNameException(String name) {
             Member member = new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL);
+
             assertThatThrownBy(() -> member.updateName(name))
                     .isInstanceOf(InvalidMemberException.class)
                     .hasMessage("올바르지 않은 이름입니다.");
-
         }
     }
 
-    @DisplayName("프로필 이미지를 변경할 때 정상적인 프로필 이미지로 변경하면 변경에 성공한다.")
-    @Test
-    void updateProfileImage() {
-        Member member = new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL);
-        member.updateProfileImage(HUNI_IMAGE_URL, List.of(HUNI_IMAGE_URL, SKRR_IMAGE_URL));
+    @DisplayName("프로필 이미지를 변경할 때 ")
+    @Nested
+    class UpdateProfileImage {
 
-        assertThat(member.getImageUrl()).isEqualTo(HUNI_IMAGE_URL);
+        @DisplayName("정상적인 프로필 이미지로 변경하면 변경에 성공한다.")
+        @Test
+        void updateProfileImage() {
+            Member member = new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL);
+            member.updateProfileImage(HUNI_IMAGE_URL, List.of(HUNI_IMAGE_URL, SKRR_IMAGE_URL));
+
+            assertThat(member.getImageUrl()).isEqualTo(HUNI_IMAGE_URL);
+        }
+
+        @DisplayName("일치하지 않는 이미지로 변경하면 예외가 발생한다.")
+        @Test
+        void updateInvalidProfileImageThrowException() {
+            Member member = new Member(HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL);
+
+            assertThatThrownBy(() -> member.updateProfileImage("no.svg", List.of(HUNI_IMAGE_URL, SKRR_IMAGE_URL)))
+                    .isInstanceOf(InvalidMemberException.class)
+                    .hasMessage("올바르지 않은 프로필 이미지입니다.");
+        }
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/member/domain/MembersTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/domain/MembersTest.java
@@ -15,6 +15,7 @@ import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_NAME;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.SKRR_SOCIAL_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,5 +34,13 @@ class MembersTest {
         List<String> emails = members.getEmails();
 
         assertThat(emails).containsExactly(HUNI_EMAIL, LALA_EMAIL, SKRR_EMAIL, HOHO_EMAIL);
+    }
+
+    @DisplayName("비어있는지 확인한다.")
+    @Test
+    void isEmpty() {
+        Members members = new Members(Collections.emptyList());
+
+        assertThat(members.isEmpty()).isTrue();
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/member/domain/NameTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/domain/NameTest.java
@@ -14,17 +14,26 @@ class NameTest {
 
     @DisplayName("이름의 앞/뒤에 공백이 있을 경우 제거한다.")
     @Test
-    void CouponContentMessageTrim() {
+    void couponContentMessageTrim() {
         Name name = new Name(" name ");
+
         assertThat(name.getValue()).isEqualTo("name");
     }
 
-    @DisplayName("올바르지 않은 이름이 들어올 경우 예외가 발생한다.")
-    @ParameterizedTest
+    @DisplayName("이름에 공백이거나 유효하지 않은 길이인 경우 예외가 발생한다.")
+    @ParameterizedTest(name = "name : {0}")
     @ValueSource(strings = {" ", "abcdef"})
     void createNameException(String value) {
         assertThatThrownBy(() -> new Name(value))
                 .isInstanceOf(InvalidMemberException.class)
                 .hasMessage("올바르지 않은 이름입니다.");
+    }
+
+    @DisplayName("이름이 동일한지 확인한다.")
+    @Test
+    void equals() {
+        Name name = new Name("hoho");
+
+        assertThat(name).isEqualTo(new Name("hoho"));
     }
 }

--- a/backend/src/test/java/com/woowacourse/thankoo/member/domain/NameTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/domain/NameTest.java
@@ -2,6 +2,7 @@ package com.woowacourse.thankoo.member.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.woowacourse.thankoo.member.exception.InvalidMemberException;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +19,13 @@ class NameTest {
         Name name = new Name(" name ");
 
         assertThat(name.getValue()).isEqualTo("name");
+    }
+
+    @DisplayName("올바른 이름은 성공한다.")
+    @ParameterizedTest(name = "name = {0}")
+    @ValueSource(strings = {"a", "abcde"})
+    void createName(String value) {
+        assertDoesNotThrow(() -> new Name(value));
     }
 
     @DisplayName("이름에 공백이거나 유효하지 않은 길이인 경우 예외가 발생한다.")

--- a/backend/src/test/java/com/woowacourse/thankoo/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/thankoo/member/presentation/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package com.woowacourse.thankoo.member.presentation;
 
+import static com.woowacourse.thankoo.common.fixtures.AuthenticationFixture.ACCESS_TOKEN;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_EMAIL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_IMAGE_URL;
 import static com.woowacourse.thankoo.common.fixtures.MemberFixture.HUNI_NAME;
@@ -48,16 +49,15 @@ class MemberControllerTest extends ControllerTest {
     @DisplayName("본인을 제외한 모든 회원을 조회힌다.")
     @Test
     void getMembersExcludeMe() throws Exception {
-        given(jwtTokenProvider.getPayload(anyString()))
-                .willReturn("1");
+        given(jwtTokenProvider.getPayload(anyString())).willReturn("1");
+
         Member huni = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL);
         Member lala = new Member(2L, LALA_NAME, LALA_EMAIL, LALA_SOCIAL_ID, SKRR_IMAGE_URL);
         List<MemberResponse> memberResponses = List.of(MemberResponse.of(lala), MemberResponse.of(huni));
-        given(memberService.getMembersExcludeMe(anyLong()))
-                .willReturn(memberResponses);
+        given(memberService.getMembersExcludeMe(anyLong())).willReturn(memberResponses);
 
         ResultActions resultActions = mockMvc.perform(get("/api/members")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpectAll(
@@ -80,16 +80,14 @@ class MemberControllerTest extends ControllerTest {
     @DisplayName("내 정보를 조회한다.")
     @Test
     void getMember() throws Exception {
-        given(jwtTokenProvider.getPayload(anyString()))
-                .willReturn("1");
-        MemberResponse memberResponse = MemberResponse.of(
-                new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL));
+        given(jwtTokenProvider.getPayload(anyString())).willReturn("1");
 
-        given(memberService.getMember(anyLong()))
-                .willReturn(memberResponse);
+        Member huni = new Member(1L, HUNI_NAME, HUNI_EMAIL, HUNI_SOCIAL_ID, SKRR_IMAGE_URL);
+        MemberResponse memberResponse = MemberResponse.of(huni);
+        given(memberService.getMember(anyLong())).willReturn(memberResponse);
 
         ResultActions resultActions = mockMvc.perform(get("/api/members/me")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpectAll(
@@ -112,14 +110,13 @@ class MemberControllerTest extends ControllerTest {
     @DisplayName("회원 이름을 수정한다.")
     @Test
     void updateName() throws Exception {
-        given(jwtTokenProvider.getPayload(anyString()))
-                .willReturn("1");
+        given(jwtTokenProvider.getPayload(anyString())).willReturn("1");
 
         MemberNameRequest memberNameRequest = new MemberNameRequest(LALA_NAME);
         doNothing().when(memberService).updateMemberName(anyLong(), any(MemberNameRequest.class));
 
         ResultActions resultActions = mockMvc.perform(put("/api/members/me/name")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(memberNameRequest)))
@@ -128,7 +125,7 @@ class MemberControllerTest extends ControllerTest {
                         status().isNoContent());
 
         resultActions.andDo(document("members/update-member-name",
-                getResponsePreprocessor(),
+                getRequestPreprocessor(),
                 requestHeaders(
                         headerWithName(HttpHeaders.AUTHORIZATION).description("token")
                 ),
@@ -140,14 +137,13 @@ class MemberControllerTest extends ControllerTest {
     @DisplayName("회원 프로필 이미지를 수정한다.")
     @Test
     void updateProfileImage() throws Exception {
-        given(jwtTokenProvider.getPayload(anyString()))
-                .willReturn("1");
+        given(jwtTokenProvider.getPayload(anyString())).willReturn("1");
 
         MemberProfileImageRequest memberProfileImageRequest = new MemberProfileImageRequest(SKRR_IMAGE_URL);
         doNothing().when(memberService).updateMemberProfileImage(anyLong(), any(MemberProfileImageRequest.class));
 
         ResultActions resultActions = mockMvc.perform(put("/api/members/me/profile-image")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(memberProfileImageRequest)))
@@ -156,7 +152,7 @@ class MemberControllerTest extends ControllerTest {
                         status().isNoContent());
 
         resultActions.andDo(document("members/update-member-profile-image",
-                getResponsePreprocessor(),
+                getRequestPreprocessor(),
                 requestHeaders(
                         headerWithName(HttpHeaders.AUTHORIZATION).description("token")
                 ),
@@ -171,8 +167,7 @@ class MemberControllerTest extends ControllerTest {
         List<ProfileImageUrlResponse> responses = Stream.of(SKRR_IMAGE_URL, HUNI_IMAGE_URL)
                 .map(ProfileImageUrlResponse::of)
                 .collect(Collectors.toList());
-        given(memberService.getProfileImages())
-                .willReturn(responses);
+        given(memberService.getProfileImages()).willReturn(responses);
 
         ResultActions resultActions = mockMvc.perform(get("/api/members/profile-images")
                         .accept(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 상세 내용
- 어제 새벽에 마무리하려했는데 조금 늦어졌어요.
- 다음 작업은 도커 작업과 시리얼 리팩토링을 진행하겠습니다.
- 수정한 부분에 대해선 코멘트로 설명 남겨둘게요.
- 이번 리팩토링은 구조나 패턴의 변경이 아니라 컨벤션과 변수명 관련해서 수정된 부분이 대부분이에요.

나머지 도메인들에 대한 부분들도 시간내서 조금씩 확인해볼게요. 

Close #511 

- [ ] 머지전 디비 테이블을 수정한다.
```sql
alter table member modify column email not null;
alter table member modify column socail_id not null;
alter table member modify column image_url varchar(2000) not null;
```
다음과 같은 쿼리를 사용할건데 확인 부탁드려요

