### PR TITLE
feat: 쿠폰 즉시 사용 api 연동

### DIFF
--- a/frontend/src/components/@shared/ConditionalViewer.tsx
+++ b/frontend/src/components/@shared/ConditionalViewer.tsx
@@ -1,0 +1,5 @@
+const ConditionalViewer = ({ children, condition, replacement }) => {
+  return <>{condition ? children : replacement}</>;
+};
+
+export default ConditionalViewer;

--- a/frontend/src/components/Reservations/ListViewReservation.tsx
+++ b/frontend/src/components/Reservations/ListViewReservation.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
 import CheckIcon from '@mui/icons-material/Check';
 import { COUPON_IMAGE, RAND_COLORS } from '../../constants/coupon';
-import { dateFormmater } from '../../utils/date';
+import { serverDateFormmater } from '../../utils/date';
 
 const ListViewReservation = ({ memberName, reservationId, couponType, meetingTime }) => {
-  const { day, date, time } = dateFormmater(meetingTime);
+  const { day, date, time } = serverDateFormmater(meetingTime);
 
   return (
     <S.Container

--- a/frontend/src/hooks/@queries/meeting.ts
+++ b/frontend/src/hooks/@queries/meeting.ts
@@ -1,11 +1,20 @@
 import { AxiosError } from 'axios';
 import { useMutation, useQuery } from 'react-query';
+import { YYYYMMDD } from 'thankoo-utils-type';
 import { client } from '../../apis/axios';
 import { API_PATH } from '../../constants/api';
 import { ErrorType } from '../../types/api';
 import { CouponType } from '../../types/coupon';
 import { Meeting, MeetingTime } from '../../types/meeting';
 import { UserProfile } from '../../types/user';
+import { sorted } from '../../utils';
+import {
+  getDayDifference,
+  getTimeDifference,
+  isExpiredDate,
+  krLocaleDateFormatter,
+  serverDateFormmater,
+} from '../../utils/date';
 
 export const MEETING_QUERY_KEYS = {
   meetings: 'meetings',
@@ -18,27 +27,35 @@ export type MeetingsResponse = {
   members: UserProfile[];
   memberName: string;
   isMeetingToday: boolean;
+  dDay: number;
+  meetingDate: YYYYMMDD;
+  meetingTime: string;
 };
 
-export const useGetMeetings = (
-  {
-    onSuccess,
-  }: {
-    onSuccess: (meeting: Meeting[]) => void;
-  } = { onSuccess: () => {} }
-) =>
-  useQuery<MeetingsResponse[]>(MEETING_QUERY_KEYS.meetings, () => getMeetingsRequest(), {
-    onSuccess: meeting => {
-      onSuccess?.(meeting);
-    },
-    select: (meetings: Meeting[]) => {
-      const today = new Date().toISOString().split('T')[0];
-      const selectedMeetings = meetings.map(meeting => ({
-        ...meeting,
-        isMeetingToday: meeting.time.meetingTime.split(' ')[0] === today,
-      }));
+const { fullDate: today } = krLocaleDateFormatter(new Date().toLocaleDateString());
 
-      return selectedMeetings;
+export const useGetMeetings = () =>
+  useQuery<MeetingsResponse[]>(MEETING_QUERY_KEYS.meetings, () => getMeetingsRequest(), {
+    select: (meetings: Meeting[]) => {
+      const validMeetings = meetings
+        .map(meeting => {
+          const { date, time } = serverDateFormmater(meeting.time.meetingTime);
+
+          return {
+            ...meeting,
+            meetingDate: date,
+            meetingTime: time.slice(0, 5),
+            isMeetingToday: date === today,
+            dDay: getDayDifference(date, today),
+          };
+        })
+        .filter(meeting => isExpiredDate(meeting.time.meetingTime));
+
+      const sortedMeetings = sorted(validMeetings, (m1, m2) =>
+        getTimeDifference(m1.time.meetingTime, m2.time.meetingTime)
+      );
+
+      return sortedMeetings;
     },
   });
 

--- a/frontend/src/hooks/CreateReservation/useCreateReservation.ts
+++ b/frontend/src/hooks/CreateReservation/useCreateReservation.ts
@@ -3,20 +3,21 @@ import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { ROUTE_PATH } from '../../constants/routes';
 import { targetCouponAtom } from '../../recoil/atom';
+import { krLocaleDateFormatter } from '../../utils/date';
 import { useGetCouponDetail } from '../@queries/coupon';
 import { usePostReservationMutation } from '../@queries/reservation';
 import useModal from '../useModal';
 import useOnSuccess from '../useOnSuccess';
 import useToast from '../useToast';
 
-const yesterday = new Date().toISOString().split('T')[0];
+const { fullDate: today } = krLocaleDateFormatter(new Date().toLocaleDateString());
 
 const useCreateReservation = () => {
   const navigate = useNavigate();
   const { insertToastItem } = useToast();
   const { successNavigate } = useOnSuccess();
   const couponId = useRecoilValue(targetCouponAtom);
-  const [date, setDate] = useState(yesterday);
+  const [date, setDate] = useState(today);
   const [time, setTime] = useState('');
   const isFilled = date && time.length;
   const { close } = useModal();
@@ -60,7 +61,7 @@ const useCreateReservation = () => {
     setReservationDate,
     createReservation,
     date,
-    yesterday,
+    today,
     time,
     setTime,
     couponDetail,

--- a/frontend/src/hooks/Main/useCouponDetail.ts
+++ b/frontend/src/hooks/Main/useCouponDetail.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { ROUTE_PATH } from '../../constants/routes';
 import { sentOrReceivedAtom, targetCouponAtom } from '../../recoil/atom';
+import { CouponDetailButton, CouponDetailButtonProps } from '../../types/coupon';
 import { COUPON_QUERY_KEY, useGetCouponDetail, usePutCompleteCoupon } from '../@queries/coupon';
 import { usePutCompleteMeeting } from '../@queries/meeting';
 import { usePutCancelReseravation, usePutReservationStatus } from '../@queries/reservation';
@@ -68,7 +69,7 @@ export const useCouponDetail = (couponId: number) => {
     },
   });
 
-  const immediateUseButton = {
+  const immediateUseButton: CouponDetailButtonProps = {
     text: '즉시 사용하기',
     bg: 'tomato',
     disabled: false,
@@ -79,8 +80,8 @@ export const useCouponDetail = (couponId: number) => {
     },
   };
 
-  const COUPON_STATUS_BUTTON = {
-    받은: {
+  const COUPON_STATUS_BUTTON: CouponDetailButton = {
+    received: {
       not_used: [
         {
           text: '예약 하기',
@@ -119,10 +120,11 @@ export const useCouponDetail = (couponId: number) => {
           },
         },
       ],
-      used: [{ text: '이미 사용된 쿠폰입니다', disable: true, bg: '#838383' }],
-      expired: [{ text: '만료된 쿠폰입니다', disable: true, bg: '#838383' }],
+      used: [{ text: '이미 사용된 쿠폰입니다', disabled: true, bg: '#838383' }],
+      immediately_used: [{ text: '이미 사용된 쿠폰입니다', disabled: true, bg: '#838383' }],
+      expired: [{ text: '만료된 쿠폰입니다', disabled: true, bg: '#838383' }],
     },
-    보낸: {
+    sent: {
       not_used: [immediateUseButton],
       reserving: [
         {
@@ -159,6 +161,7 @@ export const useCouponDetail = (couponId: number) => {
         },
       ],
       used: [{ text: '이미 사용된 쿠폰입니다', disabled: true, bg: '#838383' }],
+      immediately_used: [{ text: '이미 사용된 쿠폰입니다', disabled: true, bg: '#838383' }],
       expired: [{ text: '만료된 쿠폰입니다', disabled: true, bg: '#838383' }],
     },
   };

--- a/frontend/src/hooks/Main/useMain.ts
+++ b/frontend/src/hooks/Main/useMain.ts
@@ -1,46 +1,59 @@
 import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { sentOrReceivedAtom } from '../../recoil/atom';
-import { CouponType } from '../../types/coupon';
+import {
+  CouponStatus,
+  CouponStatusPriority,
+  CouponType,
+  UserCanSeeCoupons,
+  UserCantSeeCoupons,
+} from '../../types/coupon';
 import { sorted } from '../../utils';
 import { useGetCoupons } from '../@queries/coupon';
 
-const COUPON_STATUS_PRIORITY = {
-  not_used: 2,
+//낮을 수록 우선순위가 높다
+const COUPON_STATUS_PRIORITY: CouponStatusPriority = {
   reserving: 0,
   reserved: 1,
-  used: 10,
+  not_used: 2,
 };
+
+const userCanSeeCouponsStatus: UserCanSeeCoupons[] = ['not_used', 'reserved', 'reserving'];
+const userCantSeeCouponsStatus: UserCantSeeCoupons[] = ['expired', 'immediately_used', 'used'];
+
+// const isUserCanSeeCoupon = (status: CouponStatus): boolean => userCantSeeCouponsStatus.find(status);
 
 const useMain = () => {
   const [sentOrReceived, setSentOrReceived] = useRecoilState(sentOrReceivedAtom);
   const [currentType, setCurrentType] = useState<CouponType>('entire');
   const [showUsedCouponsWith, setShowUsedCouponsWith] = useState(false);
 
-  const { data, isLoading, error } = useGetCoupons(sentOrReceived);
+  const { data: coupons, isLoading, error } = useGetCoupons(sentOrReceived);
 
-  const edittedCouponsBySentOrReceived =
+  const couponsEditedByTransmitStatus =
     sentOrReceived === 'sent'
-      ? data?.map(coupon => {
-          const tempSender = coupon.sender;
-          const tempReceiver = coupon.receiver;
-          return { ...coupon, receiver: tempSender, sender: tempReceiver };
+      ? coupons?.map(coupon => {
+          const [receiver, sender] = [coupon.sender, coupon.receiver];
+
+          return { ...coupon, receiver, sender };
         })
-      : data;
+      : coupons;
 
-  const filteredCoupons = edittedCouponsBySentOrReceived
+  const userCanSeeCoupons = couponsEditedByTransmitStatus
     ?.filter(coupon => coupon.content.couponType === currentType || currentType === 'entire')
-    .filter(coupon => (!showUsedCouponsWith ? coupon.status !== 'used' : true));
+    .filter(coupon =>
+      !showUsedCouponsWith ? userCanSeeCouponsStatus.some(status => status === coupon.status) : true
+    );
 
-  const sortedCoupons = sorted(
-    filteredCoupons,
+  const sortedUserCanSeeCoupons = sorted(
+    userCanSeeCoupons,
     (coupon1, coupon2) =>
       COUPON_STATUS_PRIORITY[coupon1.status] - COUPON_STATUS_PRIORITY[coupon2.status]
   );
 
   return {
     setCurrentType,
-    coupons: showUsedCouponsWith ? filteredCoupons : sortedCoupons,
+    coupons: showUsedCouponsWith ? userCanSeeCoupons : sortedUserCanSeeCoupons,
     isLoading,
     error,
     currentType,

--- a/frontend/src/hooks/Main/useMain.ts
+++ b/frontend/src/hooks/Main/useMain.ts
@@ -1,12 +1,7 @@
 import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { sentOrReceivedAtom } from '../../recoil/atom';
-import {
-  CouponStatusPriority,
-  CouponType,
-  UserCanSeeCoupons,
-  UserCantSeeCoupons,
-} from '../../types/coupon';
+import { CouponStatusPriority, CouponType, UserCanSeeCoupons } from '../../types/coupon';
 import { sorted } from '../../utils';
 import { useGetCoupons } from '../@queries/coupon';
 

--- a/frontend/src/hooks/Main/useMain.ts
+++ b/frontend/src/hooks/Main/useMain.ts
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { sentOrReceivedAtom } from '../../recoil/atom';
 import {
-  CouponStatus,
   CouponStatusPriority,
   CouponType,
   UserCanSeeCoupons,
@@ -13,15 +12,13 @@ import { useGetCoupons } from '../@queries/coupon';
 
 //낮을 수록 우선순위가 높다
 const COUPON_STATUS_PRIORITY: CouponStatusPriority = {
-  reserving: 0,
-  reserved: 1,
+  reserved: 0,
+  reserving: 1,
   not_used: 2,
 };
 
+//TODO 해당하는 status가 없더라도 에러가 나지 않고 있다.
 const userCanSeeCouponsStatus: UserCanSeeCoupons[] = ['not_used', 'reserved', 'reserving'];
-const userCantSeeCouponsStatus: UserCantSeeCoupons[] = ['expired', 'immediately_used', 'used'];
-
-// const isUserCanSeeCoupon = (status: CouponStatus): boolean => userCantSeeCouponsStatus.find(status);
 
 const useMain = () => {
   const [sentOrReceived, setSentOrReceived] = useRecoilState(sentOrReceivedAtom);

--- a/frontend/src/hooks/Meetings/useMeetings.ts
+++ b/frontend/src/hooks/Meetings/useMeetings.ts
@@ -1,35 +1,15 @@
-import { useState } from 'react';
-import { Meeting } from '../../types/meeting';
-import { dayDifferenceFromToday } from '../../utils/date';
 import { useGetMeetings } from '../@queries/meeting';
 
 const useMeetings = () => {
-  const [nearestMeetingDate, setNearestMeetingDate] = useState<number>(0);
-  const { data: meetings } = useGetMeetings({
-    onSuccess: (meetings: Meeting[]) => {
-      if (!!meetings.length) {
-        const meetingDay = new Date(
-          meetings[0]?.time?.meetingTime.replaceAll('-', '/').split(' ')[0]
-        );
+  const { data: meetings } = useGetMeetings();
 
-        setNearestMeetingDate(dayDifferenceFromToday(meetingDay));
-      }
-    },
-  });
+  const meetingDateAnnouncement = meetings?.length
+    ? meetings[0].isMeetingToday
+      ? '오늘 예정된 약속이 있습니다'
+      : `${meetings[0].dDay}일 뒤 약속이 있습니다`
+    : '예정된 약속이 없습니다.';
 
-  const todayFormattedDateString = new Date().toJSON().split('T')[0];
-
-  meetings?.sort(
-    (m1, m2) =>
-      Number(new Date(m1.time?.meetingTime.replaceAll('-', '/'))) -
-      Number(new Date(m2.time?.meetingTime.replaceAll('-', '/')))
-  );
-
-  const isTodayMeetingExist = meetings?.length
-    ? meetings[0].time.meetingTime.split(' ')[0] === todayFormattedDateString
-    : false;
-
-  return { meetings, isTodayMeetingExist, nearestMeetingDate };
+  return { meetings, meetingDateAnnouncement };
 };
 
 export default useMeetings;

--- a/frontend/src/pages/CreateReservation.tsx
+++ b/frontend/src/pages/CreateReservation.tsx
@@ -21,7 +21,7 @@ const CreateReservation = () => {
     date,
     time,
     setTime,
-    yesterday,
+    today,
     couponDetail,
     createReservation,
   } = useCreateReservation();
@@ -45,7 +45,7 @@ const CreateReservation = () => {
             type='date'
             value={date}
             onChange={setReservationDate}
-            min={yesterday}
+            min={today}
             max={`${new Date().getFullYear()}-12-31`}
           />
         </S.Area>

--- a/frontend/src/pages/Meetings.tsx
+++ b/frontend/src/pages/Meetings.tsx
@@ -4,22 +4,17 @@ import MainPageLayout from '../layout/MainPageLayout';
 import { COUPON_IMAGE } from '../constants/coupon';
 import useMeetings from '../hooks/Meetings/useMeetings';
 import NoMeeting from './../components/@shared/noContent/NoMeeting';
+import ConditionalViewer from '../components/@shared/ConditionalViewer';
 
 const Meetings = () => {
-  const { meetings, isTodayMeetingExist, nearestMeetingDate } = useMeetings();
+  const { meetings, meetingDateAnnouncement } = useMeetings();
 
   return (
     <MainPageLayout>
-      <S.HeaderText>
-        {meetings?.length
-          ? isTodayMeetingExist
-            ? '오늘 예정된 약속이 있습니다'
-            : `${nearestMeetingDate}일 뒤 약속이 있습니다`
-          : '예정된 약속이 없습니다.'}
-      </S.HeaderText>
+      <S.HeaderText>{meetingDateAnnouncement}</S.HeaderText>
       <S.Body>
-        {meetings?.length !== 0 ? (
-          meetings?.map((meeting, idx) => (
+        <ConditionalViewer condition={meetings?.length !== 0} replacement={<NoMeeting />}>
+          {meetings?.map((meeting, idx) => (
             <S.Meeting isToday={meeting.isMeetingToday} key={idx}>
               {meeting.isMeetingToday && <S.TodayStrap>오늘</S.TodayStrap>}
               <S.CouponImageWrapper>
@@ -33,19 +28,17 @@ const Meetings = () => {
                 <S.DateWrapper>
                   <S.DetailWrapper>
                     <S.Label>날짜</S.Label>
-                    <span>{meeting.time?.meetingTime.split(' ')[0]}</span>
+                    <span>{meeting.meetingDate}</span>
                   </S.DetailWrapper>
                   <S.DetailWrapper>
                     <S.Label>시간</S.Label>
-                    <span>{meeting.time?.meetingTime.split(' ')[1].slice(0, 5)}</span>
+                    <span>{meeting.meetingTime}</span>
                   </S.DetailWrapper>
                 </S.DateWrapper>
               </S.MeetingDetail>
             </S.Meeting>
-          ))
-        ) : (
-          <NoMeeting />
-        )}
+          ))}
+        </ConditionalViewer>
       </S.Body>
     </MainPageLayout>
   );

--- a/frontend/src/types/coupon.ts
+++ b/frontend/src/types/coupon.ts
@@ -54,3 +54,7 @@ type CouponDetailButtonPropsByCouponStatus = {
 export type CouponDetailButton = {
   [T in CouponTransmitStatus]: CouponDetailButtonPropsByCouponStatus;
 };
+
+export type UserCanSeeCoupons = 'reserving' | 'reserved' | 'not_used';
+export type UserCantSeeCoupons = Exclude<CouponStatus, UserCanSeeCoupons>;
+export type CouponStatusPriority = { [T in UserCanSeeCoupons]: number };

--- a/frontend/src/types/meeting.ts
+++ b/frontend/src/types/meeting.ts
@@ -1,6 +1,5 @@
 import { CouponType } from './coupon';
 import { UserProfile } from './user';
-// 2022-10-08 17:00:00
 
 export type MeetingTime = {
   meetingTime: string;

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,17 +1,4 @@
-export const dayDifferenceFromToday = meetingDay => {
-  const today = new Date();
-
-  const dayForCal =
-    `${meetingDay.getFullYear()}` +
-    `${String(meetingDay.getMonth()).padStart(2, '0')}` +
-    `${String(meetingDay.getDate()).padStart(2, '0')}`;
-  const todayForCal =
-    `${today.getFullYear()}` +
-    `${String(today.getMonth()).padStart(2, '0')}` +
-    `${String(today.getDate()).padStart(2, '0')}`;
-
-  return Number(dayForCal) - Number(todayForCal);
-};
+import { YYYYMMDD } from 'thankoo-utils-type';
 
 export const engDayTo요일 = {
   Mon: '월',
@@ -23,10 +10,37 @@ export const engDayTo요일 = {
   Sun: '일',
 };
 
-export const dateFormmater = serverDate => {
+export const isExpiredDate = (time): boolean => {
+  const date = new Date();
+  const now = date.toLocaleDateString() + ' ' + date.toLocaleTimeString().split(' ')[1];
+
+  return getTimeDifference(now, time) < 0;
+};
+
+export const getTimeDifference = (from, to): number =>
+  Number(new Date(from)) - Number(new Date(to));
+
+export const getDayDifference = (from, to) =>
+  Math.floor((Number(new Date(from)) - Number(new Date(to))) / (1000 * 60 * 60 * 24));
+
+export const serverDateFormmater = serverDate => {
   const day = engDayTo요일[new Date(serverDate.split(' ')[0]).toString().slice(0, 3)];
-  const date = serverDate.split(' ')[0];
+  const date: YYYYMMDD = serverDate.split(' ')[0];
   const time = serverDate.split(' ')[1].slice(0, 5);
 
   return { day, date, time };
+};
+
+export const krLocaleDateFormatter = localeDate => {
+  const [year, month, date] = localeDate
+    .split('.')
+    .map(string => string.trim())
+    .map(string => string.padStart(2, '0'));
+
+  return {
+    year,
+    month,
+    date,
+    fullDate: `${year}-${month}-${date}` as YYYYMMDD,
+  };
 };


### PR DESCRIPTION
## 상세 내용
- 쿠폰 즉시 사용 기능을 연동한다.
- 홈 화면에서 유저가 `볼 수 있는 쿠폰 상태`와 `볼 수 없는 쿠폰 상태`를 각각 타입으로 만들고 구분한다.

Close #526 

