### PR TITLE
refactor: Button 컴포넌트 생성

### DIFF
--- a/frontend/src/components/@shared/Button.tsx
+++ b/frontend/src/components/@shared/Button.tsx
@@ -3,17 +3,21 @@ import styled from '@emotion/styled';
 
 export type ButtonSize = 'medium' | 'small' | 'large';
 export type ButtonColor = 'primary' | 'secondary' | 'primaryLight' | 'secondaryLight';
-
-type ButtonProps = {
+export interface ButtonProps {
   size?: ButtonSize;
   color?: ButtonColor;
   isDisabled?: boolean;
-};
+}
 
-const ButtonStyleOptions = {
+export const ButtonStyleOptions = {
   size: {
     medium: '1.3rem',
     small: '1rem',
+    large: '1.7rem',
+  },
+  fontSize: {
+    medium: '1.4rem',
+    small: '1.2rem',
     large: '1.7rem',
   },
   bg: {
@@ -32,7 +36,7 @@ const ButtonStyleOptions = {
 const Button = styled.button<ButtonProps>`
   ${({ size = 'medium', color = 'primary', isDisabled = false }) => css`
     width: 100%;
-    font-size: ${ButtonStyleOptions.size[size]};
+    font-size: ${ButtonStyleOptions.fontSize[size]};
     padding: ${ButtonStyleOptions.size[size]} 1rem;
     background-color: ${ButtonStyleOptions.bg[color]};
     color: ${ButtonStyleOptions.fontColor[color]};

--- a/frontend/src/components/@shared/Button.tsx
+++ b/frontend/src/components/@shared/Button.tsx
@@ -1,0 +1,50 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+export type ButtonSize = 'medium' | 'small' | 'large';
+export type ButtonColor = 'primary' | 'secondary' | 'primaryLight' | 'secondaryLight';
+
+type ButtonProps = {
+  size?: ButtonSize;
+  color?: ButtonColor;
+  isDisabled?: boolean;
+};
+
+const ButtonStyleOptions = {
+  size: {
+    medium: '1.3rem',
+    small: '1rem',
+    large: '1.7rem',
+  },
+  bg: {
+    primary: 'tomato',
+    primaryLight: '#cdcac7',
+    secondary: '#404040',
+    secondaryLight: '#4a4a4a',
+  },
+  fontColor: {
+    primary: 'white',
+    secondary: '#b2b2b2',
+    secondaryLight: 'white',
+  },
+};
+
+const Button = styled.button<ButtonProps>`
+  ${({ size = 'medium', color = 'primary', isDisabled = false }) => css`
+    width: 100%;
+    font-size: ${ButtonStyleOptions.size[size]};
+    padding: ${ButtonStyleOptions.size[size]} 1rem;
+    background-color: ${ButtonStyleOptions.bg[color]};
+    color: ${ButtonStyleOptions.fontColor[color]};
+    border: none;
+    border-radius: 4px;
+    ${isDisabled &&
+    css`
+      background-color: ${ButtonStyleOptions.bg['secondary']};
+      color: ${ButtonStyleOptions.fontColor['secondary']};
+      cursor: not-allowed;
+    `}
+  `}
+`;
+
+export default Button;

--- a/frontend/src/components/@shared/LongButton.tsx
+++ b/frontend/src/components/@shared/LongButton.tsx
@@ -1,0 +1,17 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import Button, { ButtonProps, ButtonStyleOptions } from './Button';
+
+interface LongButtonProps extends ButtonProps {}
+
+const LongButton = styled(Button)<LongButtonProps>`
+  ${({ size = 'medium' }) => css`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: ${ButtonStyleOptions.size[size]} 2rem;
+    border-radius: 30px;
+  `}
+`;
+
+export default LongButton;

--- a/frontend/src/components/@shared/noContent/NoReceivedCoupon.tsx
+++ b/frontend/src/components/@shared/noContent/NoReceivedCoupon.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 import { ROUTE_PATH } from '../../../constants/routes';
 import { FlexCenter } from '../../../styles/mixIn';
+import Button from '../Button';
 import IconEmptyList from '../LogoEmptyList';
 
 const NoReceivedCoupon = () => {
@@ -17,7 +18,7 @@ const NoReceivedCoupon = () => {
           기브 앤 테이크를 노려볼까요...!?
         </S.Comment>
         <Link to={ROUTE_PATH.SELECT_RECEIVER}>
-          <S.Button>쿠폰 보내기</S.Button>
+          <Button size='small'>쿠폰 보내기</Button>
         </Link>
       </S.Box>
     </S.Container>
@@ -46,14 +47,6 @@ const S = {
   Comment: styled.h3`
     font-size: 1.5rem;
     line-height: 30px;
-  `,
-  Button: styled.button`
-    background-color: ${({ theme }) => theme.primary};
-    color: ${({ theme }) => theme.button.abled};
-    padding: 1rem;
-    border: none;
-    border-radius: 6px;
-    margin-top: 20px;
   `,
 };
 export default NoReceivedCoupon;

--- a/frontend/src/components/@shared/noContent/NoSendCoupon.tsx
+++ b/frontend/src/components/@shared/noContent/NoSendCoupon.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 import { ROUTE_PATH } from '../../../constants/routes';
 import { FlexCenter } from '../../../styles/mixIn';
+import Button from '../Button';
 import IconEmptyList from '../LogoEmptyList';
 
 const NoSendCoupon = () => {
@@ -17,7 +18,7 @@ const NoSendCoupon = () => {
           원하는 상대에게 쿠폰을 선물해보세요!
         </S.Comment>
         <Link to={`${ROUTE_PATH.SELECT_RECEIVER}`}>
-          <S.Button>선물하기💛</S.Button>
+          <Button size='small'>선물하기💛</Button>
         </Link>
       </S.Box>
     </S.Container>
@@ -46,14 +47,6 @@ const S = {
   Comment: styled.h3`
     font-size: 1.5rem;
     line-height: 30px;
-  `,
-  Button: styled.button`
-    background-color: ${({ theme }) => theme.primary};
-    color: ${({ theme }) => theme.button.abled};
-    padding: 8px 12px;
-    border: none;
-    border-radius: 6px;
-    margin-top: 20px;
   `,
 };
 export default NoSendCoupon;

--- a/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
+++ b/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
@@ -35,10 +35,6 @@ const ConfirmReservationModal = ({ submit, time, date, receiver }) => {
 
 export default ConfirmReservationModal;
 
-type ButtonProps = {
-  primary?: boolean;
-};
-
 const S = {
   ConfirmContentWrapper: styled.div`
     display: flex;

--- a/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
+++ b/frontend/src/components/CreateReservation/ConfirmReservationModal.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import useModal from '../../hooks/useModal';
+import Button from '../@shared/Button';
 import BottomSheetLayout from '../@shared/Modal/BottomSheetLayout';
 
 const ConfirmReservationModal = ({ submit, time, date, receiver }) => {
@@ -23,10 +24,10 @@ const ConfirmReservationModal = ({ submit, time, date, receiver }) => {
         </S.ConfirmContentWrapper>
       </S.SpaceBetween>
       <S.ButtonWrapper>
-        <S.Button onClick={submit} primary>
-          예약
-        </S.Button>
-        <S.Button onClick={close}>취소</S.Button>
+        <Button onClick={close} color='secondaryLight'>
+          취소
+        </Button>
+        <Button onClick={submit}>예약</Button>
       </S.ButtonWrapper>
     </BottomSheetLayout>
   );
@@ -64,15 +65,5 @@ const S = {
     width: 100%;
     display: flex;
     gap: 5px;
-  `,
-  Button: styled.button<ButtonProps>`
-    width: 100%;
-    border: none;
-    border-radius: 4px;
-    color: white;
-    font-size: 1.5rem;
-    padding: 1rem 0;
-
-    background-color: ${({ theme, primary }) => (primary ? theme.primary : '#4a4a4a')};
   `,
 };

--- a/frontend/src/components/CreateReservation/CreateReservationSuccess.tsx
+++ b/frontend/src/components/CreateReservation/CreateReservationSuccess.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 import { useRecoilState, useResetRecoilState } from 'recoil';
 import { ROUTE_PATH } from '../../constants/routes';
+import Button from '../@shared/Button';
 import SuccessAnimation from '../@shared/SuccessAnimation';
 import { onSuccessContentAtom, ReservationNavAtom } from './../../recoil/atom';
 
@@ -43,17 +44,16 @@ const CreateReservationSuccess = ({ receiver, date, time }) => {
         </S.ContenstWrapper>
         <S.ButtonWrapper>
           <S.StyledLink to={ROUTE_PATH.EXACT_MAIN} onClick={pageReset}>
-            <S.Button>홈으로</S.Button>
+            <Button color='secondaryLight'>홈으로</Button>
           </S.StyledLink>
           <S.StyledLink to={ROUTE_PATH.RESERVATIONS} onClick={pageReset}>
-            <S.Button
+            <Button
               onClick={() => {
                 setReservationNav('sent');
               }}
-              primary
             >
               예약 확인하기
-            </S.Button>
+            </Button>
           </S.StyledLink>
         </S.ButtonWrapper>
       </S.Wrapper>
@@ -111,15 +111,6 @@ const S = {
   ButtonWrapper: styled.div`
     ${SpaceBetween}
     gap:5px;
-  `,
-  Button: styled.button<ButtonProps>`
-    border: none;
-    border-radius: 4px;
-    background-color: ${({ theme, primary }) => (primary ? theme.primary : '#4a4a4a')};
-    padding: 1rem;
-    font-size: 1.5rem;
-    color: white;
-    width: 100%;
   `,
   StyledLink: styled(Link)`
     width: 100%;

--- a/frontend/src/components/CreateReservation/CreateReservationSuccess.tsx
+++ b/frontend/src/components/CreateReservation/CreateReservationSuccess.tsx
@@ -63,10 +63,6 @@ const CreateReservationSuccess = ({ receiver, date, time }) => {
 
 export default CreateReservationSuccess;
 
-type ButtonProps = {
-  primary?: boolean;
-};
-
 const SpaceBetween = {
   display: 'flex',
   'justify-content': 'space-between',

--- a/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
+++ b/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
@@ -48,7 +48,7 @@ const ConfirmCouponContentModal = ({
         <S.ConfirmContentText>{message}</S.ConfirmContentText>
       </S.ConfirmContentWrapper>
       <S.ButtonWrapper>
-        <Button color='secondary' onClick={close}>
+        <Button color='secondaryLight' onClick={close}>
           취소
         </Button>
         <Button onClick={submit}>전송</Button>
@@ -58,10 +58,6 @@ const ConfirmCouponContentModal = ({
 };
 
 export default ConfirmCouponContentModal;
-
-type ButtonProps = {
-  primary?: boolean;
-};
 
 const S = {
   ReceiversWrapper: styled.div`

--- a/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
+++ b/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import useModal from '../../hooks/useModal';
 import { CouponType, couponTypes } from '../../types/coupon';
 import { UserProfile } from '../../types/user';
+import Button from '../@shared/Button';
 import BottomSheetLayout from '../@shared/Modal/BottomSheetLayout';
 import { BASE_URL } from './../../constants/api';
 
@@ -47,10 +48,10 @@ const ConfirmCouponContentModal = ({
         <S.ConfirmContentText>{message}</S.ConfirmContentText>
       </S.ConfirmContentWrapper>
       <S.ButtonWrapper>
-        <S.Button onClick={submit} primary>
-          전송
-        </S.Button>
-        <S.Button onClick={close}>취소</S.Button>
+        <Button color='secondary' onClick={close}>
+          취소
+        </Button>
+        <Button onClick={submit}>전송</Button>
       </S.ButtonWrapper>
     </BottomSheetLayout>
   );
@@ -111,15 +112,5 @@ const S = {
     width: 100%;
     display: flex;
     gap: 5px;
-  `,
-  Button: styled.button<ButtonProps>`
-    width: 100%;
-    border: none;
-    border-radius: 4px;
-    color: white;
-    padding: 1rem 0;
-    font-size: 1.5rem;
-
-    background-color: ${({ theme, primary }) => (primary ? theme.primary : '#4a4a4a')};
   `,
 };

--- a/frontend/src/components/EnterCouponContent/EnterCouponContentSuccess.tsx
+++ b/frontend/src/components/EnterCouponContent/EnterCouponContentSuccess.tsx
@@ -78,10 +78,6 @@ const EnterCouponContentSuccess = ({ receivers, title, message, couponType }) =>
 
 export default EnterCouponContentSuccess;
 
-type ButtonProps = {
-  primary?: boolean;
-};
-
 const SpaceBetween = {
   display: 'flex',
   justifyContent: 'space-between',

--- a/frontend/src/components/EnterCouponContent/EnterCouponContentSuccess.tsx
+++ b/frontend/src/components/EnterCouponContent/EnterCouponContentSuccess.tsx
@@ -6,6 +6,7 @@ import { useRecoilState, useResetRecoilState } from 'recoil';
 import { ROUTE_PATH } from '../../constants/routes';
 import { checkedUsersAtom, sentOrReceivedAtom } from '../../recoil/atom';
 import { couponTypes } from '../../types/coupon';
+import Button from '../@shared/Button';
 import SuccessAnimation from '../@shared/SuccessAnimation';
 import { BASE_URL } from './../../constants/api';
 import { onSuccessContentAtom } from './../../recoil/atom';
@@ -61,14 +62,13 @@ const EnterCouponContentSuccess = ({ receivers, title, message, couponType }) =>
         </S.ContenstWrapper>
         <S.ButtonWrapper>
           <S.StyledLink to={ROUTE_PATH.EXACT_MAIN} onClick={pageReset}>
-            <S.Button
+            <Button
               onClick={() => {
                 setSentOrReceived('sent');
               }}
-              primary
             >
               쿠폰 확인하기
-            </S.Button>
+            </Button>
           </S.StyledLink>
         </S.ButtonWrapper>
       </S.Wrapper>
@@ -149,15 +149,6 @@ const S = {
   ButtonWrapper: styled.div`
     ${SpaceBetween}
     gap:5px;
-  `,
-  Button: styled.button<ButtonProps>`
-    border: none;
-    border-radius: 4px;
-    background-color: ${({ theme, primary }) => (primary ? theme.primary : '#4a4a4a')};
-    padding: 1rem;
-    color: white;
-    width: 100%;
-    font-size: 1.5rem;
   `,
   StyledLink: styled(Link)`
     width: 100%;

--- a/frontend/src/components/Main/CouponDetail.reservation.tsx
+++ b/frontend/src/components/Main/CouponDetail.reservation.tsx
@@ -99,16 +99,6 @@ const S = {
     /* height: 15%; */
     align-items: flex-end;
   `,
-  Button: styled.button`
-    border: none;
-    border-radius: 4px;
-    background-color: ${({ theme }) => theme.primary};
-    color: ${({ theme }) => theme.button.abled.color};
-    width: 100%;
-    padding: 1rem;
-    font-size: 1.5rem;
-    height: fit-content;
-  `,
   UseCouponLink: styled(Link)`
     width: 100%;
   `,

--- a/frontend/src/components/Main/CouponDetail.tsx
+++ b/frontend/src/components/Main/CouponDetail.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
 import { useCouponDetail } from '../../hooks/Main/useCouponDetail';
 import { Coupon, CouponDetail } from '../../types/coupon';
+import Button from '../@shared/Button';
 import CloseButton from '../@shared/CloseButton';
 import PageSlider from '../@shared/PageSlider';
 import CouponDetailCoupon from './ConponDetail.coupon';
@@ -31,14 +32,9 @@ const CouponDetail = ({ couponId }: { couponId: number }) => {
             <S.Footer>
               <S.ButtonWrapper>
                 {buttonOptions.map((button, idx) => (
-                  <S.Button
-                    key={idx}
-                    bg={button.bg}
-                    disabled={button.disabled}
-                    onClick={button?.onClick}
-                  >
+                  <Button key={idx} {...button}>
                     {button.text}
-                  </S.Button>
+                  </Button>
                 ))}
               </S.ButtonWrapper>
             </S.Footer>
@@ -100,18 +96,7 @@ const S = {
     width: 100%;
     gap: 5px;
   `,
-  Button: styled.button<ButtonProps>`
-    border: none;
-    border-radius: 8px;
-    background-color: ${({ theme, disabled, bg }) =>
-      disabled ? theme.button.disbaled.background : bg};
-    color: ${({ theme, disabled }) =>
-      disabled ? theme.button.disbaled.color : theme.button.abled.color};
-    width: 100%;
-    padding: 1rem;
-    font-size: 1.5rem;
-    height: fit-content;
-  `,
+
   UseCouponLink: styled(Link)`
     width: 100%;
   `,

--- a/frontend/src/components/Main/CouponDetail.tsx
+++ b/frontend/src/components/Main/CouponDetail.tsx
@@ -47,11 +47,6 @@ const CouponDetail = ({ couponId }: { couponId: number }) => {
 
 export default CouponDetail;
 
-type ButtonProps = {
-  bg: string;
-  disabled: boolean;
-};
-
 const S = {
   Container: styled.section`
     position: fixed;

--- a/frontend/src/components/Main/QRCouponRegisterModal.tsx
+++ b/frontend/src/components/Main/QRCouponRegisterModal.tsx
@@ -14,6 +14,7 @@ import { onMountToCenterModal, unMountCenterToButtomModal } from '../../styles/A
 import { FlexColumn } from '../../styles/mixIn';
 import { ErrorType } from '../../types/api';
 import { couponTypes } from '../../types/coupon';
+import Button from '../@shared/Button';
 
 const QRCouponRegisterModal = ({
   QRCode,
@@ -67,15 +68,8 @@ const QRCouponRegisterModal = ({
           <S.ContentText>{couponTypes[QRCode.couponType.toLocaleLowerCase()]}</S.ContentText>
         </S.ContentWrapper>
         <S.ButtonWrapper>
-          <S.Button
-            onClick={() => {
-              postQRSerial();
-            }}
-            primary
-          >
-            등록
-          </S.Button>
-          <S.Button
+          <Button
+            color='secondaryLight'
             onClick={() => {
               close();
               localStorage.removeItem('query');
@@ -83,7 +77,14 @@ const QRCouponRegisterModal = ({
             }}
           >
             취소
-          </S.Button>
+          </Button>
+          <Button
+            onClick={() => {
+              postQRSerial();
+            }}
+          >
+            등록
+          </Button>
         </S.ButtonWrapper>
       </S.Modal>
     </S.Container>
@@ -178,15 +179,5 @@ const S = {
     width: 100%;
     display: flex;
     gap: 5px;
-  `,
-  Button: styled.button<ButtonProps>`
-    width: 100%;
-    border: none;
-    border-radius: 4px;
-    color: white;
-    padding: 1rem 0;
-    font-size: 1.5rem;
-
-    background-color: ${({ theme, primary }) => (primary ? theme.primary : '#4a4a4a')};
   `,
 };

--- a/frontend/src/components/Main/QRCouponRegisterModal.tsx
+++ b/frontend/src/components/Main/QRCouponRegisterModal.tsx
@@ -93,10 +93,6 @@ const QRCouponRegisterModal = ({
 
 export default QRCouponRegisterModal;
 
-type ButtonProps = {
-  primary?: boolean;
-};
-
 const S = {
   Container: styled.section`
     position: fixed;

--- a/frontend/src/components/Profile/SelectProfileImgModal.tsx
+++ b/frontend/src/components/Profile/SelectProfileImgModal.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import CheckIcon from '@mui/icons-material/Check';
 import { useState } from 'react';
 import { ProfileIconList } from '../../constants/profileIcon';
+import Button from '../@shared/Button';
 import { modalMountTime, modalUnMountTime } from './../../constants/modal';
 import useModal from './../../hooks/useModal';
 import ProfileIcon from './../@shared/ProfileIcon';
@@ -27,16 +28,17 @@ const SelectProfileImgModal = ({ editUserProfileImage }) => {
           ))}
         </S.ProfileContainer>
         <S.ButtonWrapper>
-          <S.Button
+          <Button color='secondaryLight' onClick={close}>
+            취소
+          </Button>
+          <Button
             onClick={() => {
               editUserProfileImage(selected);
               close();
             }}
-            primary
           >
             변경하기
-          </S.Button>
-          <S.Button onClick={close}>취소</S.Button>
+          </Button>
         </S.ButtonWrapper>
       </S.Wrapper>
     </S.Container>
@@ -170,14 +172,5 @@ const S = {
     width: 100%;
     display: flex;
     gap: 5px;
-  `,
-  Button: styled.button<ButtonProps>`
-    width: 100%;
-    border: none;
-    border-radius: 4px;
-    color: white;
-    padding: 1rem 0;
-    font-size: 1.7rem;
-    background-color: ${({ theme, primary }) => (primary ? theme.primary : '#4a4a4a')};
   `,
 };

--- a/frontend/src/components/Profile/SelectProfileImgModal.tsx
+++ b/frontend/src/components/Profile/SelectProfileImgModal.tsx
@@ -49,9 +49,7 @@ export default SelectProfileImgModal;
 type ConfirmCouponContentModalProps = {
   show: boolean;
 };
-type ButtonProps = {
-  primary?: boolean;
-};
+
 type IconWrapperProp = {
   isSelected: boolean;
 };

--- a/frontend/src/hooks/Main/useCouponDetail.ts
+++ b/frontend/src/hooks/Main/useCouponDetail.ts
@@ -71,8 +71,7 @@ export const useCouponDetail = (couponId: number) => {
 
   const immediateUseButton: CouponDetailButtonProps = {
     text: '즉시 사용하기',
-    bg: 'tomato',
-    disabled: false,
+    color: 'primary',
     onClick: () => {
       if (confirm('만남은 즐거우셨나요? \n쿠폰을 사용 완료 하겠습니다.')) {
         completeCoupon();
@@ -85,8 +84,7 @@ export const useCouponDetail = (couponId: number) => {
       not_used: [
         {
           text: '예약 하기',
-          bg: '#5c5c5c',
-          disabled: false,
+          color: 'secondaryLight',
           onClick: () => {
             setTargetCouponId(couponId);
             close();
@@ -98,8 +96,7 @@ export const useCouponDetail = (couponId: number) => {
       reserving: [
         {
           text: '예약 취소',
-          bg: '#5c5c5c',
-          disabled: false,
+          color: 'secondaryLight',
           onClick: () => {
             if (confirm('예약을 취소하시겠습니까?')) {
               cancelReservation();
@@ -111,8 +108,7 @@ export const useCouponDetail = (couponId: number) => {
       reserved: [
         {
           text: '사용 완료',
-          bg: 'tomato',
-          disabled: false,
+          color: 'primary',
           onClick: () => {
             if (confirm('만남은 즐거우셨나요? \n쿠폰을 사용 완료 하겠습니다')) {
               completeMeeting();
@@ -120,17 +116,16 @@ export const useCouponDetail = (couponId: number) => {
           },
         },
       ],
-      used: [{ text: '이미 사용된 쿠폰입니다', disabled: true, bg: '#838383' }],
-      immediately_used: [{ text: '이미 사용된 쿠폰입니다', disabled: true, bg: '#838383' }],
-      expired: [{ text: '만료된 쿠폰입니다', disabled: true, bg: '#838383' }],
+      used: [{ text: '이미 사용된 쿠폰입니다', isDisabled: true, color: 'secondary' }],
+      immediately_used: [{ text: '이미 사용된 쿠폰입니다', isDisabled: true, color: 'secondary' }],
+      expired: [{ text: '만료된 쿠폰입니다', isDisabled: true, color: 'secondary' }],
     },
     sent: {
       not_used: [immediateUseButton],
       reserving: [
         {
           text: '거절',
-          disabled: false,
-          bg: '#838383',
+          color: 'secondaryLight',
           onClick: () => {
             if (confirm('예약을 거절하시겠습니까?')) {
               handleReservation('deny');
@@ -139,8 +134,7 @@ export const useCouponDetail = (couponId: number) => {
         },
         {
           text: '승인',
-          disabled: false,
-          bg: 'tomato',
+          color: 'primary',
           onClick: () => {
             if (confirm('예약을 승인하시겠습니까?')) {
               handleReservation('accept');
@@ -151,8 +145,7 @@ export const useCouponDetail = (couponId: number) => {
       reserved: [
         {
           text: '사용 완료',
-          disabled: false,
-          bg: 'tomato',
+          color: 'primary',
           onClick: () => {
             if (confirm('만남은 즐거우셨나요? \n쿠폰을 사용 완료하겠습니다')) {
               completeMeeting();
@@ -160,9 +153,9 @@ export const useCouponDetail = (couponId: number) => {
           },
         },
       ],
-      used: [{ text: '이미 사용된 쿠폰입니다', disabled: true, bg: '#838383' }],
-      immediately_used: [{ text: '이미 사용된 쿠폰입니다', disabled: true, bg: '#838383' }],
-      expired: [{ text: '만료된 쿠폰입니다', disabled: true, bg: '#838383' }],
+      used: [{ text: '이미 사용된 쿠폰입니다', isDisabled: true, color: 'secondary' }],
+      immediately_used: [{ text: '이미 사용된 쿠폰입니다', isDisabled: true, color: 'secondary' }],
+      expired: [{ text: '만료된 쿠폰입니다', isDisabled: true, color: 'secondary' }],
     },
   };
 

--- a/frontend/src/pages/CreateReservation.tsx
+++ b/frontend/src/pages/CreateReservation.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import AccessAlarmsIcon from '@mui/icons-material/AccessAlarms';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
@@ -13,6 +12,7 @@ import PageLayout from '../layout/PageLayout';
 import { ROUTE_PATH } from './../constants/routes';
 import useCreateReservation from './../hooks/CreateReservation/useCreateReservation';
 import HeaderText from '../layout/HeaderText';
+import LongButton from '../components/@shared/LongButton';
 
 const CreateReservation = () => {
   const {
@@ -57,8 +57,8 @@ const CreateReservation = () => {
           <Time setSelectedTime={setTime} selectedTime={time} selectedDate={date} />
         </S.TimeArea>
       </S.Body>
-      <S.LongButton
-        disabled={!isFilled}
+      <LongButton
+        isDisabled={!isFilled}
         onClick={() => {
           show();
           setModalContent(
@@ -73,7 +73,7 @@ const CreateReservation = () => {
       >
         약속 신청하기
         <ArrowForwardIosIcon />
-      </S.LongButton>
+      </LongButton>
     </S.PageLayout>
   );
 };
@@ -138,31 +138,6 @@ const S = {
   Calander: styled.div`
     height: 21rem;
     background-color: white;
-  `,
-  LongButton: styled.button`
-    position: fixed;
-    border-radius: 30px;
-    font-size: 1.7rem;
-    padding: 1rem 2rem;
-    bottom: 5%;
-    left: 50%;
-    transform: translateX(-50%);
-    border: none;
-    display: flex;
-    width: 90%;
-    justify-content: space-between;
-    align-items: center;
-    ${({ disabled, theme }) =>
-      disabled
-        ? css`
-            background-color: ${theme.button.disbaled.background};
-            color: ${theme.button.disbaled.color};
-            cursor: not-allowed;
-          `
-        : css`
-            background-color: ${theme.button.active.background};
-            color: ${theme.button.active.color};
-          `}
   `,
 };
 

--- a/frontend/src/pages/EnterCouponContent.tsx
+++ b/frontend/src/pages/EnterCouponContent.tsx
@@ -13,6 +13,7 @@ import ConfirmCouponContentModal from '../components/EnterCouponContent/ConfirmC
 import useModal from '../hooks/useModal';
 import HeaderText from '../layout/HeaderText';
 import { couponTypeKeys, couponTypes } from '../types/coupon';
+import LongButton from '../components/@shared/LongButton';
 
 const couponTypesWithoutEntire = couponTypeKeys.filter(type => type !== 'entire');
 
@@ -70,7 +71,7 @@ const EnterCouponContent = () => {
           />
         </S.Form>
       </S.Body>
-      <S.LongButton
+      <LongButton
         onClick={() => {
           show();
           setModalContent(
@@ -87,7 +88,7 @@ const EnterCouponContent = () => {
       >
         {checkedUsers.length}명에게 쿠폰 전송하기
         <ArrowForwardIosIcon />
-      </S.LongButton>
+      </LongButton>
     </PageLayout>
   );
 };
@@ -143,27 +144,6 @@ const S = {
     &:focus {
       outline: ${({ theme }) => `3px solid ${theme.primary}`};
     }
-  `,
-  LongButton: styled.button`
-    border: none;
-    border-radius: 30px;
-    font-size: 18px;
-    margin: 0 3vw;
-    padding: 10px 20px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    ${({ disabled, theme }) =>
-      disabled
-        ? css`
-            background-color: ${theme.button.disbaled.background};
-            color: ${theme.button.disbaled.color};
-            cursor: not-allowed;
-          `
-        : css`
-            background-color: ${theme.button.active.background};
-            color: ${theme.button.active.color};
-          `}
   `,
   CouponBox: styled.div`
     margin: 0 auto;

--- a/frontend/src/pages/EnterNickname.tsx
+++ b/frontend/src/pages/EnterNickname.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import Header from '../layout/Header';
 import Input from '../components/@shared/Input';
@@ -6,6 +5,7 @@ import PageLayout from '../layout/PageLayout';
 import useEnterNickname from '../hooks/EnterNickname/useEnterNickname';
 import { USER_NICKNAME_MAX_LENGTH } from './../constants/users';
 import HeaderText from '../layout/HeaderText';
+import Button from '../components/@shared/Button';
 
 const EnterNickname = () => {
   const { email, nickname, setNickname, signUpWithNickname } = useEnterNickname();
@@ -32,9 +32,9 @@ const EnterNickname = () => {
               maxLength={USER_NICKNAME_MAX_LENGTH}
             />
           </S.FlexColumn>
-          <S.Button disabled={nickname.trim().length === 0} type='submit'>
+          <Button isDisabled={nickname.trim().length === 0} type='submit'>
             회원가입 완료
-          </S.Button>
+          </Button>
         </S.Form>
       </S.Body>
     </S.PageLayout>
@@ -68,24 +68,5 @@ const S = {
   `,
   Label: styled.label`
     font-size: 1.7rem;
-  `,
-  Button: styled.button`
-    color: white;
-    border-radius: 10px;
-    border: none;
-    padding: 8px;
-    font-size: 17px;
-    background-color: ${({ theme }) => theme.primary};
-    ${({ disabled, theme }) =>
-      disabled
-        ? css`
-            background-color: ${theme.button.disbaled.background};
-            color: ${theme.button.disbaled.color};
-            cursor: not-allowed;
-          `
-        : css`
-            background-color: ${theme.button.active.background};
-            color: ${theme.button.active.color};
-          `}
   `,
 };

--- a/frontend/src/pages/Organization.tsx
+++ b/frontend/src/pages/Organization.tsx
@@ -3,39 +3,7 @@ import PageLayout from '../layout/PageLayout';
 import BirdLogoWhite from '../components/@shared/LogoWhite';
 import { css } from '@emotion/react';
 import { ORGANIZATIONS } from '../routes/Router';
-
-type ButtonProps = {
-  size?: 'medium' | 'small' | 'large';
-  type?: 'primary' | 'secondary' | 'primaryLight' | 'secondaryLight';
-};
-
-const ButtonStyleOptions = {
-  size: {
-    medium: '1.5rem',
-    small: '1rem',
-    large: '2rem',
-  },
-  bg: {
-    primary: 'tomato',
-    primaryLight: '#cdcac7',
-    secondary: '',
-    secondaryLight: '',
-  },
-  color: {
-    primary: 'white',
-  },
-};
-
-const Button = styled.button<ButtonProps>`
-  ${({ size = 'medium', type = 'primary' }) => css`
-    width: 100%;
-    padding: ${ButtonStyleOptions.size[size]} 1rem;
-    background-color: ${ButtonStyleOptions.bg[type]};
-    color: ${ButtonStyleOptions.color[type]};
-    border: none;
-    border-radius: 4px;
-  `}
-`;
+import Button from '../components/@shared/Button';
 
 const Organization = () => {
   const organization = ORGANIZATIONS[0];
@@ -62,7 +30,7 @@ const Organization = () => {
           </div>
         </S.Body>
         <S.JoinSection>
-          <Button size='medium'>{organization.organizationName}에 참여하기</Button>
+          <Button>{organization.organizationName}에 참여하기</Button>
         </S.JoinSection>
       </S.Inner>
     </S.Container>

--- a/frontend/src/pages/SelectReceiver.tsx
+++ b/frontend/src/pages/SelectReceiver.tsx
@@ -10,6 +10,7 @@ import useSelectReceiver from '../hooks/SelectReceiver/useSelectReceiver';
 import { ROUTE_PATH } from '../constants/routes';
 import HeaderText from '../layout/HeaderText';
 import MainPageLayout from '../layout/MainPageLayout';
+import LongButton from '../components/@shared/LongButton';
 
 const SelectReceiver = () => {
   const {
@@ -44,22 +45,17 @@ const SelectReceiver = () => {
             />
           )}
           <S.SendButtonBox>
-            <S.LongButton
-              to={checkedUsers.length ? `${ROUTE_PATH.ENTER_COUPON_CONTENT}` : '#'}
-              disabled={!checkedUsers.length}
-            >
-              다 고르셨나요?
-              <ArrowForwardIosIcon />
-            </S.LongButton>
+            <S.ButtonLink to={checkedUsers.length ? `${ROUTE_PATH.ENTER_COUPON_CONTENT}` : '#'}>
+              <LongButton isDisabled={!checkedUsers.length}>
+                다 고르셨나요?
+                <ArrowForwardIosIcon />
+              </LongButton>
+            </S.ButtonLink>
           </S.SendButtonBox>
         </S.Section>
       </S.Body>
     </MainPageLayout>
   );
-};
-
-type ButtonProps = {
-  disabled: boolean;
 };
 
 type SectionProps = {
@@ -124,29 +120,8 @@ const S = {
             height: calc(100% - 7rem);
           `}
   `,
-  LongButton: styled(Link)<ButtonProps>`
-    bottom: 11%;
+  ButtonLink: styled(Link)`
     width: 100%;
-    max-width: 680px;
-    transition: all ease-in-out 0.1s;
-    ${({ disabled, theme }) =>
-      disabled
-        ? css`
-            background-color: ${theme.button.disbaled.background};
-            color: ${theme.button.disbaled.color};
-            cursor: not-allowed;
-          `
-        : css`
-            background-color: ${theme.button.active.background};
-            color: ${theme.button.active.color};
-          `}
-    border: none;
-    border-radius: 30px;
-    font-size: 1.7rem;
-    padding: 1rem 2rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
   `,
 };
 

--- a/frontend/src/types/coupon.ts
+++ b/frontend/src/types/coupon.ts
@@ -1,4 +1,5 @@
 import { YYYYMMDD } from 'thankoo-utils-type';
+import { ButtonColor } from '../components/@shared/Button';
 import { Meeting } from './meeting';
 import { Reservation } from './reservation';
 import { UserProfile } from './user';
@@ -38,12 +39,10 @@ export const couponTypeValues = Object.values(couponTypes);
 export const couponTypeKeys = Object.keys(couponTypes);
 export type CouponType = keyof typeof couponTypes;
 
-type CouponDetailButtonBGColors = 'tomato' | '#838383' | '#5c5c5c';
-
 export type CouponDetailButtonProps = {
   text: string;
-  bg: CouponDetailButtonBGColors;
-  disabled: boolean;
+  color: ButtonColor;
+  isDisabled?: boolean;
   onClick?: () => void;
 };
 


### PR DESCRIPTION
## 상세 내용
- 커스텀 Button 컴포넌트를 생성하고 해당 컴포넌트로 다 통일한다.
- props로는 size와 color, isDisabled를 받는다.
- size로 height를 조절하며 width는 100%로 고정이다. width를 줄이고 싶다면 사용하는 곳에서 wrapper를 만드는 식으로 사용한다. size 기반으로 font-size도 고정이다.
- color는 primary,primaryLight,secondary,secondaryLight가 있다. 해당 색에 맞게 폰트 색도 변경된다. 따로 지정할 수는 없게했다.
- isDisabled를 통해 click event를 막고 disabled 스타일을 적용하도록 했다. button의 disabled 옵션을 사용할까 했지만, 실제 html 옵션을 사용하면 개발자도구에서 해당 attribute를 제거하는 방법으로 문제가 생길 수 있을 것 같아서 isDisabled라는 이름의 local state 기반으로 판단하도록 했다.