### PR TITLE
feat: api fetch에 대한 suspense와 errorboundary를 추가한다.

### DIFF
--- a/frontend/src/apis/queryClient.ts
+++ b/frontend/src/apis/queryClient.ts
@@ -18,10 +18,13 @@ const mutateErrorHandler = error => {
   authErrorHandler(error);
 };
 const retryHandler = (failureCount, error) => {
+  const defaultRetryCount = 3;
+
   if (
     error.response?.status === INVALID_AUTH_STATUS ||
     error.response?.data.errorCode === INVALID_MEMBER_ERROR_CODE ||
-    error.response?.data.errorCode === INVALID_AUTH_ERROR_CODE
+    error.response?.data.errorCode === INVALID_AUTH_ERROR_CODE ||
+    failureCount === defaultRetryCount
   ) {
     return false;
   }

--- a/frontend/src/apis/queryClient.ts
+++ b/frontend/src/apis/queryClient.ts
@@ -17,20 +17,6 @@ const queryErrorHandler = error => {
 const mutateErrorHandler = error => {
   authErrorHandler(error);
 };
-const retryHandler = (failureCount, error) => {
-  const defaultRetryCount = 3;
-
-  if (
-    error.response?.status === INVALID_AUTH_STATUS ||
-    error.response?.data.errorCode === INVALID_MEMBER_ERROR_CODE ||
-    error.response?.data.errorCode === INVALID_AUTH_ERROR_CODE ||
-    failureCount === defaultRetryCount
-  ) {
-    return false;
-  }
-
-  return true;
-};
 
 const authErrorHandler = (error: AxiosError) => {
   const {
@@ -47,13 +33,13 @@ const defaultOptions: QueryClientConfig = {
   defaultOptions: {
     queries: {
       onError: queryErrorHandler,
-      retry: retryHandler,
+      retry: 3,
       refetchOnWindowFocus: false,
       suspense: true,
     },
     mutations: {
       onError: mutateErrorHandler,
-      retry: retryHandler,
+      retry: 3,
     },
   },
 };

--- a/frontend/src/apis/queryClient.ts
+++ b/frontend/src/apis/queryClient.ts
@@ -49,6 +49,7 @@ const defaultOptions: QueryClientConfig = {
       onError: queryErrorHandler,
       retry: retryHandler,
       refetchOnWindowFocus: false,
+      suspense: true,
     },
     mutations: {
       onError: mutateErrorHandler,

--- a/frontend/src/components/@shared/Button.tsx
+++ b/frontend/src/components/@shared/Button.tsx
@@ -7,6 +7,7 @@ export interface ButtonProps {
   size?: ButtonSize;
   color?: ButtonColor;
   isDisabled?: boolean;
+  isLoading?: boolean;
 }
 
 export const ButtonStyleOptions = {
@@ -22,6 +23,7 @@ export const ButtonStyleOptions = {
   },
   bg: {
     primary: 'tomato',
+    primaryBright: '#ff7e67',
     primaryLight: '#cdcac7',
     secondary: '#404040',
     secondaryLight: '#4a4a4a',
@@ -34,7 +36,7 @@ export const ButtonStyleOptions = {
 };
 
 const Button = styled.button<ButtonProps>`
-  ${({ size = 'medium', color = 'primary', isDisabled = false }) => css`
+  ${({ size = 'medium', color = 'primary', isDisabled = false, isLoading = false }) => css`
     width: 100%;
     font-size: ${ButtonStyleOptions.fontSize[size]};
     padding: ${ButtonStyleOptions.size[size]} 1rem;
@@ -48,6 +50,16 @@ const Button = styled.button<ButtonProps>`
       color: ${ButtonStyleOptions.fontColor['secondary']};
       cursor: not-allowed;
       pointer-events: none;
+    `}
+    ${isLoading &&
+    css`
+      background-color: ${ButtonStyleOptions.bg['primaryBright']};
+      cursor: default;
+      pointer-events: none;
+
+      ::after {
+        content: '중..';
+      }
     `}
   `}
 `;

--- a/frontend/src/components/@shared/ChoiceSlider.tsx
+++ b/frontend/src/components/@shared/ChoiceSlider.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { createContext, Dispatch, SetStateAction, useContext, useState } from 'react';
+import { createContext, Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
 
 const ChoiceSlider = ({ children }) => {
   return <S.Container>{children}</S.Container>;
@@ -64,7 +64,10 @@ ChoiceSlider.Options = ({ children, ...props }) => {
   const { toggle, setLength } = useContext(ToggleContext);
   const hasChildren = Array.isArray(children.props.children);
   const length = hasChildren ? children.props.children.length : 1;
-  setLength(length);
+
+  useEffect(() => {
+    setLength(length);
+  }, [length]);
 
   return (
     <S.Options show={toggle} {...props}>

--- a/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
+++ b/frontend/src/components/EnterCouponContent/ConfirmCouponContentModal.tsx
@@ -79,9 +79,7 @@ const ConfirmCouponContentModal = ({
         </Button>
         <Button
           onClick={() => {
-            if (!isLoading) {
-              sendCoupon();
-            }
+            sendCoupon();
           }}
           isLoading={isLoading}
         >

--- a/frontend/src/components/Hearts/Members.tsx
+++ b/frontend/src/components/Hearts/Members.tsx
@@ -1,0 +1,153 @@
+import styled from '@emotion/styled';
+import useHeartsMembers from '../../hooks/Hearts/useHeartsMembers';
+import { FlexCenter } from '../../styles/mixIn';
+import { BASE_URL } from './../../constants/api';
+
+const Members = ({ searchKeyword }: { searchKeyword: string }) => {
+  const { matchedUsers, sentMembers, receivedMembers, postHeart } = useHeartsMembers(searchKeyword);
+
+  return (
+    <S.MembersContainer>
+      {matchedUsers?.map(user => {
+        const canSend =
+          !sentMembers?.some(sentHistory => sentHistory.receiverId === user.id) ||
+          receivedMembers?.some(receivedHistory => receivedHistory.senderId === user.id);
+
+        const count = sentMembers?.find(sentHistory => sentHistory.receiverId === user.id)?.count;
+        const lastReceived =
+          sentMembers?.find(sentHistory => sentHistory.receiverId === user.id)?.modifiedAt ||
+          receivedMembers?.find(receiveHistory => receiveHistory.senderId === user.id)?.modifiedAt;
+        const modifiedLastReceived = lastReceived?.split(' ')[0];
+        const receivedUserCount = receivedMembers?.find(
+          receiveHistory => receiveHistory.senderId === user.id
+        )?.count;
+
+        return (
+          <S.UserWrappr key={user.id}>
+            <S.UserImageWrapper>
+              <S.UserImage src={`${BASE_URL}${user.imageUrl}`} />
+            </S.UserImageWrapper>
+            <S.UserName>{user.name}</S.UserName>
+            {modifiedLastReceived && <S.ModifiedAt>{`${modifiedLastReceived}에 콕!`}</S.ModifiedAt>}
+
+            <S.CountWrapper>
+              <S.CountLabel>연속</S.CountLabel>{' '}
+              <S.CountNum>{`${count || receivedUserCount || 0}회`}</S.CountNum>
+            </S.CountWrapper>
+            <S.SendButtonWrapper>
+              <S.SendButton
+                canSend={canSend}
+                onClick={() => {
+                  if (canSend) {
+                    postHeart(user.id);
+                  }
+                }}
+              >
+                콕
+              </S.SendButton>
+            </S.SendButtonWrapper>
+          </S.UserWrappr>
+        );
+      })}
+    </S.MembersContainer>
+  );
+};
+
+export default Members;
+
+type CheckBoxProp = { canSend: boolean };
+
+const S = {
+  MembersContainer: styled.div`
+    width: 100%;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+
+    overflow: auto;
+    height: calc(100% - 5rem);
+    padding-bottom: 17rem;
+  `,
+  UserWrappr: styled.div`
+    width: 99.5%;
+    height: 5rem;
+    display: grid;
+    grid-template-areas:
+      'ui un ct cb'
+      'ui sn ct cb';
+    grid-template-columns: 17% 50% 13% 20%;
+    grid-template-rows: 60% 40%;
+    border-radius: 5px;
+    gap: 2px 0;
+  `,
+  UserImageWrapper: styled.div`
+    grid-area: ui;
+    width: 100%;
+    height: 100%;
+    ${FlexCenter};
+  `,
+
+  UserImage: styled.img`
+    width: 30px;
+
+    border-radius: 50%;
+    object-fit: cover;
+  `,
+  UserName: styled.span`
+    grid-area: un;
+    height: 100%;
+    line-height: 3.5rem;
+    font-size: 16px;
+    color: ${({ theme }) => theme.page.color};
+  `,
+  ModifiedAt: styled.div`
+    grid-area: sn;
+    height: 100%;
+    font-size: 1.3rem;
+    color: ${({ theme }) => theme.page.subColor};
+  `,
+  CountWrapper: styled.div`
+    grid-area: ct;
+    display: flex;
+    flex-direction: column;
+    color: ${({ theme }) => theme.page.color};
+    padding: 0.6rem 0;
+    text-align: center;
+    gap: 3px;
+    justify-content: center;
+  `,
+  CountLabel: styled.div`
+    color: #c9c9c9;
+    font-size: 1rem;
+  `,
+  CountNum: styled.div`
+    color: mediumspringgreen; //10회 미만 darksalmon 10회 이상 mediumspringgreen 30회 이상 fuchsia 100회 이상 gold
+    font-size: 1.5rem;
+  `,
+  SendButtonWrapper: styled.div`
+    grid-area: cb;
+    ${FlexCenter}
+    margin-right: 5px;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+  `,
+  SendButton: styled.span<CheckBoxProp>`
+    display: grid;
+    place-items: center;
+
+    width: 80%;
+    height: 80%;
+    border-radius: 8px;
+
+    text-align: center;
+    background-color: ${({ canSend }) => (canSend ? `#ff7a62` : `#adadad`)};
+    font-size: 1.3rem;
+    line-height: 3rem;
+
+    color: ${({ canSend }) => (canSend ? 'white' : '#7a7a7a')};
+    cursor: ${({ canSend }) => (canSend ? 'pointer' : '')};
+  `,
+};

--- a/frontend/src/components/Main/GridViewCoupons.tsx
+++ b/frontend/src/components/Main/GridViewCoupons.tsx
@@ -1,10 +1,14 @@
 import styled from '@emotion/styled';
+import { Suspense } from 'react';
 import { COUPON_STATUS_STRAP_TEXT } from '../../constants/coupon';
 import { CouponStatus, CouponTransmitStatus, CouponType } from '../../types/coupon';
+import CustomErrorBoundary from './../../errors/CustomErrorBoundary';
+import ErrorFallBack from './../../errors/ErrorFallBack';
 import useGridViewCoupons from './../../hooks/Main/useGridViewCoupons';
 import ModalWrapper from './../@shared/Modal/ModalWrapper';
 import NoReceivedCoupon from './../@shared/noContent/NoReceivedCoupon';
 import NoSendCoupon from './../@shared/noContent/NoSendCoupon';
+import Spinner from './../@shared/Spinner';
 import CouponDetail from './CouponDetail';
 import GridViewCoupon from './GridViewCoupon';
 
@@ -33,7 +37,16 @@ const GridViewCoupons = ({
   return (
     <S.Container>
       {coupons.map(coupon => (
-        <ModalWrapper key={coupon.couponId} modal={<CouponDetail couponId={coupon.couponId} />}>
+        <ModalWrapper
+          key={coupon.couponId}
+          modal={
+            <CustomErrorBoundary fallbackComponent={ErrorFallBack}>
+              <Suspense fallback={<Spinner />}>
+                <CouponDetail couponId={coupon.couponId} />
+              </Suspense>
+            </CustomErrorBoundary>
+          }
+        >
           <S.Relative>
             {isCompleted(coupon.status) && <S.CompleteDeem>사용 완료</S.CompleteDeem>}
             {isOnReserve(coupon.status) && (

--- a/frontend/src/components/Main/GridViewCoupons.tsx
+++ b/frontend/src/components/Main/GridViewCoupons.tsx
@@ -1,15 +1,34 @@
 import styled from '@emotion/styled';
 import { COUPON_STATUS_STRAP_TEXT } from '../../constants/coupon';
-import { Coupon, CouponStatus } from '../../types/coupon';
+import { CouponStatus, CouponTransmitStatus, CouponType } from '../../types/coupon';
+import useGridViewCoupons from './../../hooks/Main/useGridViewCoupons';
+import ModalWrapper from './../@shared/Modal/ModalWrapper';
+import NoReceivedCoupon from './../@shared/noContent/NoReceivedCoupon';
+import NoSendCoupon from './../@shared/noContent/NoSendCoupon';
 import CouponDetail from './CouponDetail';
 import GridViewCoupon from './GridViewCoupon';
-import ModalWrapper from '../@shared/Modal/ModalWrapper';
 
 const strapStatus = ['reserving', 'reserved'];
 
-const GridViewCoupons = ({ coupons }: { coupons: Coupon[] }) => {
+const GridViewCoupons = ({
+  currentType,
+  sentOrReceived,
+  showUsedCouponsWith,
+}: {
+  currentType: CouponType;
+  sentOrReceived: CouponTransmitStatus;
+  showUsedCouponsWith: boolean;
+}) => {
+  const { coupons } = useGridViewCoupons(currentType, sentOrReceived, showUsedCouponsWith);
   const isOnReserve = status => strapStatus.includes(status);
   const isCompleted = status => status === 'used' || status === 'immediately_used';
+
+  if (coupons.length === 0 && sentOrReceived === 'sent') {
+    return <NoSendCoupon />;
+  }
+  if (coupons.length === 0 && sentOrReceived === 'received') {
+    return <NoReceivedCoupon />;
+  }
 
   return (
     <S.Container>

--- a/frontend/src/components/Meeting/ListViewMeetings.tsx
+++ b/frontend/src/components/Meeting/ListViewMeetings.tsx
@@ -1,0 +1,117 @@
+import styled from '@emotion/styled';
+import { COUPON_IMAGE } from '../../constants/coupon';
+import useMeetings from './../../hooks/Meetings/useMeetings';
+import HeaderText from './../../layout/HeaderText';
+import ConditionalViewer from './../@shared/ConditionalViewer';
+import NoMeeting from './../@shared/noContent/NoMeeting';
+
+const ListViewMeetings = () => {
+  const { meetings, meetingDateAnnouncement } = useMeetings();
+
+  return (
+    <>
+      <S.HeaderText>{meetingDateAnnouncement}</S.HeaderText>
+      <S.Body>
+        <ConditionalViewer condition={meetings?.length !== 0} replacement={<NoMeeting />}>
+          {meetings?.map((meeting, idx) => (
+            <S.Meeting isToday={meeting.isMeetingToday} key={idx}>
+              {meeting.isMeetingToday && <S.TodayStrap>오늘</S.TodayStrap>}
+              <S.CouponImageWrapper>
+                <S.CouponTypeImage src={COUPON_IMAGE[meeting.couponType]} />
+              </S.CouponImageWrapper>
+              <S.MeetingDetail>
+                <S.DetailWrapper>
+                  <S.Label>만날 사람</S.Label>
+                  <span>{meeting.memberName}</span>
+                </S.DetailWrapper>
+                <S.DateWrapper>
+                  <S.DetailWrapper>
+                    <S.Label>날짜</S.Label>
+                    <span>{meeting.meetingDate}</span>
+                  </S.DetailWrapper>
+                  <S.DetailWrapper>
+                    <S.Label>시간</S.Label>
+                    <span>{meeting.meetingTime}</span>
+                  </S.DetailWrapper>
+                </S.DateWrapper>
+              </S.MeetingDetail>
+            </S.Meeting>
+          ))}
+        </ConditionalViewer>
+      </S.Body>
+    </>
+  );
+};
+
+export default ListViewMeetings;
+
+type MeetingWrapperProps = {
+  isToday: boolean;
+};
+
+const S = {
+  HeaderText: styled(HeaderText)`
+    color: white;
+  `,
+  Body: styled.section`
+    display: block;
+    flex-direction: column;
+    gap: 1rem;
+    height: 100%;
+    overflow: auto;
+  `,
+  Meeting: styled.div<MeetingWrapperProps>`
+    position: relative;
+    width: 100%;
+    color: white;
+    border-radius: 4px;
+    display: flex;
+    gap: 20px;
+    box-sizing: border-box;
+    align-items: center;
+    padding: 10px;
+    background-color: #4a4a4a;
+    border: ${({ theme, isToday }) => (isToday ? '2px solid tomato' : 'unset')};
+    overflow: hidden;
+    font-size: 1.5rem;
+    margin: 10px 0;
+  `,
+  TodayStrap: styled.span`
+    position: absolute;
+    font-size: 15px;
+    top: 7px;
+    right: -20px;
+    padding: 5px 30px;
+    background-color: ${({ theme }) => theme.primary};
+    color: white;
+    transform: rotate(40deg);
+  `,
+  MeetingDetail: styled.div`
+    width: 100%;
+    display: flex;
+    flex-flow: column;
+    gap: 5px;
+  `,
+  DetailWrapper: styled.div`
+    display: flex;
+    flex-flow: column;
+    gap: 3px;
+  `,
+  CouponImageWrapper: styled.div`
+    width: 65px;
+    display: flex;
+    justify-content: center;
+  `,
+  CouponTypeImage: styled.img`
+    width: 40px;
+    object-fit: cover;
+  `,
+  Label: styled.span`
+    color: #838383;
+    font-size: 12px;
+  `,
+  DateWrapper: styled.div`
+    display: flex;
+    justify-content: space-between;
+  `,
+};

--- a/frontend/src/components/Profile/ProfileInfo.tsx
+++ b/frontend/src/components/Profile/ProfileInfo.tsx
@@ -10,7 +10,7 @@ const ProfileInfo = () => {
 
   return (
     <S.Body>
-      <ProfileUserImage src={profile ? profile?.imageUrl : 'default'} />
+      <ProfileUserImage src={profile?.imageUrl || 'default'} />
       <S.UserInfoBox>
         <S.UserInfoItem>
           <S.Bold>이름</S.Bold>

--- a/frontend/src/components/Profile/ProfileInfo.tsx
+++ b/frontend/src/components/Profile/ProfileInfo.tsx
@@ -1,0 +1,112 @@
+import styled from '@emotion/styled';
+import { USER_NICKNAME_MAX_LENGTH } from './../../constants/users';
+import useUserProfile from './../../hooks/Profile/useUserProfile';
+import Input from './../@shared/Input';
+import ProfileUserImage from './ProfileUserImage';
+
+const ProfileInfo = () => {
+  const { profile, isNameEdit, name, handleClickModifyNameButton, exchangeCount, setName } =
+    useUserProfile();
+
+  return (
+    <S.Body>
+      <ProfileUserImage src={profile ? profile?.imageUrl : 'default'} />
+      <S.UserInfoBox>
+        <S.UserInfoItem>
+          <S.Bold>이름</S.Bold>
+          {isNameEdit ? (
+            <Input
+              type='text'
+              value={name}
+              setValue={setName}
+              placeholder='이름을 입력해주세요'
+              onKeyDown={e => {
+                if (e.code === 'Enter') {
+                  handleClickModifyNameButton();
+                }
+              }}
+              maxLength={USER_NICKNAME_MAX_LENGTH}
+            />
+          ) : (
+            <span>{name}</span>
+          )}
+          <S.ModifyNameButton onClick={handleClickModifyNameButton}>
+            {isNameEdit ? '저장' : '수정'}
+          </S.ModifyNameButton>
+        </S.UserInfoItem>
+        <S.UserInfoItem>
+          <S.Bold>이메일</S.Bold>
+          <span>{profile?.email}</span>
+        </S.UserInfoItem>
+      </S.UserInfoBox>
+      <S.UserCouponInfo>
+        <S.UserCouponInfoItem>
+          <span>보낸 쿠폰 수</span>
+          <span>{exchangeCount?.sentCount}</span>
+        </S.UserCouponInfoItem>
+        <S.UserCouponInfoItem>
+          <span>받은 쿠폰 수</span>
+          <span>{exchangeCount?.receivedCount}</span>
+        </S.UserCouponInfoItem>
+      </S.UserCouponInfo>
+    </S.Body>
+  );
+};
+
+export default ProfileInfo;
+
+const S = {
+  Body: styled.div`
+    display: flex;
+    flex-direction: column;
+    height: 50%;
+    margin: 0 3vw;
+
+    span {
+      font-size: 1.6rem;
+    }
+  `,
+  UserInfoBox: styled.div`
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 1.5rem;
+    gap: 1rem;
+    margin: 3rem 0 2rem;
+    border-bottom: ${({ theme }) => `1px solid ${theme.primary}`};
+  `,
+  UserInfoItem: styled.div`
+    display: grid;
+    grid-template-columns: 30% 50% 20%;
+    align-items: center;
+    color: white;
+    height: 40px;
+  `,
+  Bold: styled.span`
+    font-weight: 700;
+    font-size: 1.6rem;
+  `,
+  ModifyNameButton: styled.button`
+    background-color: transparent;
+    font-size: 1.6rem;
+    border: none;
+    font-weight: 600;
+    color: ${({ theme }) => theme.primary};
+    text-align: right;
+  `,
+  UserCouponInfo: styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: space-between;
+    gap: 2rem;
+  `,
+  UserCouponInfoItem: styled.div`
+    display: flex;
+    justify-content: space-between;
+    color: white;
+  `,
+  SubHeader: styled.div`
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  `,
+};

--- a/frontend/src/components/Reservations/ListReservationItem.tsx
+++ b/frontend/src/components/Reservations/ListReservationItem.tsx
@@ -1,10 +1,10 @@
-import useReservation from '../../hooks/Reservations/useReservation';
+import useListReservationItem from '../../hooks/Reservations/useListReservationItem';
 import { CouponTransmitStatus, CouponType } from '../../types/coupon';
 import { MeetingTime } from '../../types/meeting';
 import Slider from '../@shared/ChoiceSlider';
-import ListViewReservation from './ListViewReservation';
+import ListViewReservationDetail from './ListViewReservation';
 
-type ReservationProps = {
+type ListReservationItemProps = {
   couponType: CouponType;
   time: MeetingTime;
   memberName: string;
@@ -12,20 +12,20 @@ type ReservationProps = {
   transmitStatus: CouponTransmitStatus;
 };
 
-const Reservation = ({
+const ListReservationItem = ({
   couponType,
   time,
   memberName,
   reservationId,
   transmitStatus,
-}: ReservationProps) => {
-  const { handleClickOption } = useReservation({ reservationId, time });
+}: ListReservationItemProps) => {
+  const { handleClickOption } = useListReservationItem({ reservationId, time });
 
   return (
     <Slider>
       <Slider.Inner>
         <Slider.Content>
-          <ListViewReservation
+          <ListViewReservationDetail
             couponType={couponType}
             meetingTime={time.meetingTime}
             memberName={memberName}
@@ -34,7 +34,6 @@ const Reservation = ({
         </Slider.Content>
         <Slider.Options>
           {transmitStatus === 'received' ? (
-            /** TODO index는 Slider.OptionItem에서 자동으로 부여해주도록 수정 */
             <>
               <Slider.OptionItem
                 index={1}
@@ -66,4 +65,4 @@ const Reservation = ({
   );
 };
 
-export default Reservation;
+export default ListReservationItem;

--- a/frontend/src/components/Reservations/ListViewReservation.tsx
+++ b/frontend/src/components/Reservations/ListViewReservation.tsx
@@ -3,7 +3,7 @@ import CheckIcon from '@mui/icons-material/Check';
 import { COUPON_IMAGE, RAND_COLORS } from '../../constants/coupon';
 import { serverDateFormmater } from '../../utils/date';
 
-const ListViewReservation = ({ memberName, reservationId, couponType, meetingTime }) => {
+const ListViewReservationDetail = ({ memberName, reservationId, couponType, meetingTime }) => {
   const { day, date, time } = serverDateFormmater(meetingTime);
 
   return (
@@ -18,7 +18,7 @@ const ListViewReservation = ({ memberName, reservationId, couponType, meetingTim
   );
 };
 
-export default ListViewReservation;
+export default ListViewReservationDetail;
 
 type ContentProp = {
   backgroundColor: string;

--- a/frontend/src/components/Reservations/ListViewReservations.tsx
+++ b/frontend/src/components/Reservations/ListViewReservations.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import { ReservationOrderType } from '../../hooks/Reservations/useReservations';
+import useListViewReservations from './../../hooks/Reservations/useListViewReservations';
+import NoReservation from './../@shared/noContent/NoReservation';
+import ListReservationItem from './ListReservationItem';
+
+const ListViewReservations = ({ orderBy }: { orderBy: ReservationOrderType }) => {
+  const { reservations } = useListViewReservations(orderBy);
+
+  return (
+    <S.ListView>
+      {reservations.length > 0 ? (
+        reservations.map(reservation => (
+          <ListReservationItem
+            key={reservation.reservationId}
+            transmitStatus={orderBy}
+            {...reservation}
+          />
+        ))
+      ) : (
+        <NoReservation />
+      )}
+    </S.ListView>
+  );
+};
+
+const S = {
+  ListView: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    height: 70vh;
+    overflow: auto;
+  `,
+};
+
+export default ListViewReservations;

--- a/frontend/src/components/SelectReceiver/ListViewUsers.tsx
+++ b/frontend/src/components/SelectReceiver/ListViewUsers.tsx
@@ -1,19 +1,22 @@
 import styled from '@emotion/styled';
 import { UserProfile } from '../../types/user';
+import useListViewUsers from './../../hooks/SelectReceiver/useListViewUsers';
 import ListViewUser from './ListViewUser';
 
 const ListViewUsers = ({
-  users,
   onClickUser,
   isCheckedUser,
+  searchKeyword,
 }: {
-  users: UserProfile[];
   onClickUser: (user: UserProfile) => void;
   isCheckedUser: (user: UserProfile) => boolean;
+  searchKeyword: string;
 }) => {
+  const { matchedUsers } = useListViewUsers(searchKeyword);
+
   return (
     <S.Container>
-      {users?.map(user => (
+      {matchedUsers.map(user => (
         <ListViewUser
           key={user.id}
           user={user}

--- a/frontend/src/errors/CustomErrorBoundary.tsx
+++ b/frontend/src/errors/CustomErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import React, { ErrorInfo } from 'react';
+
+type Props = {
+  children?: React.ReactNode;
+  fallbackComponent: React.ElementType;
+  onError?: () => {};
+};
+
+type State = {
+  hasError: boolean;
+};
+
+const initialState: State = {
+  hasError: false,
+};
+
+class CustomErrorBoundary extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+    this.state = initialState;
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    console.log('error occured');
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    if (this.props.onError) {
+      this.props.onError();
+    }
+  }
+
+  reset() {
+    this.setState(initialState);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <>
+          <this.props.fallbackComponent />
+          <button onClick={this.reset.bind(this)}>재시도</button>
+        </>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default CustomErrorBoundary;

--- a/frontend/src/errors/CustomErrorBoundary.tsx
+++ b/frontend/src/errors/CustomErrorBoundary.tsx
@@ -1,4 +1,7 @@
+import styled from '@emotion/styled';
 import React, { ErrorInfo } from 'react';
+import { FlexCenter } from '../styles/mixIn';
+import Button from './../components/@shared/Button';
 
 type Props = {
   children?: React.ReactNode;
@@ -38,10 +41,10 @@ class CustomErrorBoundary extends React.Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <>
+        <S.Container>
           <this.props.fallbackComponent />
-          <button onClick={this.reset.bind(this)}>재시도</button>
-        </>
+          <Button onClick={this.reset.bind(this)}>다시 시도하기</Button>
+        </S.Container>
       );
     }
     return this.props.children;
@@ -49,3 +52,20 @@ class CustomErrorBoundary extends React.Component<Props, State> {
 }
 
 export default CustomErrorBoundary;
+
+const S = {
+  Container: styled.div`
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+
+    ${FlexCenter};
+    flex-direction: column;
+    gap: 2.5rem;
+
+    button {
+      width: 100%;
+    }
+  `,
+};

--- a/frontend/src/errors/ErrorFallBack.tsx
+++ b/frontend/src/errors/ErrorFallBack.tsx
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+const ErrorFallBack = () => {
+  return <S.Wrapper>에러발생!</S.Wrapper>;
+};
+
+export default ErrorFallBack;
+
+const S = {
+  Wrapper: styled.div`
+    color: white;
+  `,
+};

--- a/frontend/src/errors/ErrorFallBack.tsx
+++ b/frontend/src/errors/ErrorFallBack.tsx
@@ -1,13 +1,14 @@
 import styled from '@emotion/styled';
 
 const ErrorFallBack = () => {
-  return <S.Wrapper>에러발생!</S.Wrapper>;
+  return <S.Wrapper>예기치 못한 에러가 발생했습니다!</S.Wrapper>;
 };
 
 export default ErrorFallBack;
 
 const S = {
   Wrapper: styled.div`
+    font-size: 2rem;
     color: white;
   `,
 };

--- a/frontend/src/hooks/@queries/coupon.ts
+++ b/frontend/src/hooks/@queries/coupon.ts
@@ -2,8 +2,8 @@ import { AxiosError } from 'axios';
 import { useMutation, useQuery } from 'react-query';
 import { client } from '../../apis/axios';
 import { API_PATH } from '../../constants/api';
-import { Coupon, CouponDetail } from '../../types/coupon';
 import { ErrorType } from '../../types/api';
+import { Coupon, CouponDetail } from '../../types/coupon';
 
 const SENT_OR_RECEIVED_API_PATH = {
   received: API_PATH.RECEIVED_COUPONS_ALL,
@@ -34,8 +34,13 @@ export const useGetCouponDetail = (
   );
 
 export const useGetCoupons = sentOrReceived =>
-  useQuery<Coupon[]>([COUPON_QUERY_KEY.coupon, sentOrReceived], () =>
-    getCouponsRequest(sentOrReceived)
+  useQuery<Coupon[]>(
+    [COUPON_QUERY_KEY.coupon, sentOrReceived],
+    () => getCouponsRequest(sentOrReceived),
+    {
+      suspense: true,
+      useErrorBoundary: true,
+    }
   );
 
 export const usePostCouponMutation = ({ receiverIds, content }, { onSuccess = () => {} } = {}) =>

--- a/frontend/src/hooks/@queries/coupon.ts
+++ b/frontend/src/hooks/@queries/coupon.ts
@@ -34,13 +34,8 @@ export const useGetCouponDetail = (
   );
 
 export const useGetCoupons = sentOrReceived =>
-  useQuery<Coupon[]>(
-    [COUPON_QUERY_KEY.coupon, sentOrReceived],
-    () => getCouponsRequest(sentOrReceived),
-    {
-      suspense: true,
-      useErrorBoundary: true,
-    }
+  useQuery<Coupon[]>([COUPON_QUERY_KEY.coupon, sentOrReceived], () =>
+    getCouponsRequest(sentOrReceived)
   );
 
 export const usePostCouponMutation = ({ receiverIds, content }, { onSuccess = () => {} } = {}) =>

--- a/frontend/src/hooks/@queries/meeting.ts
+++ b/frontend/src/hooks/@queries/meeting.ts
@@ -32,7 +32,7 @@ export type MeetingsResponse = {
   meetingTime: string;
 };
 
-const { fullDate: today } = krLocaleDateFormatter(new Date().toLocaleDateString());
+const { fullDate: todayFullDate } = krLocaleDateFormatter(new Date().toLocaleDateString());
 
 export const useGetMeetings = () =>
   useQuery<MeetingsResponse[]>(MEETING_QUERY_KEYS.meetings, () => getMeetingsRequest(), {
@@ -40,6 +40,7 @@ export const useGetMeetings = () =>
       const validMeetings = meetings
         .map(meeting => {
           const { date, time } = serverDateFormmater(meeting.time.meetingTime);
+          const today = todayFullDate.split('-')[0];
 
           return {
             ...meeting,

--- a/frontend/src/hooks/EnterCouponContent/useEnterCouponContent.ts
+++ b/frontend/src/hooks/EnterCouponContent/useEnterCouponContent.ts
@@ -5,14 +5,11 @@ import { ROUTE_PATH } from '../../constants/routes';
 import { checkedUsersAtom } from '../../recoil/atom';
 import { CouponTransmitableType } from '../../types/coupon';
 import { UserProfile } from '../../types/user';
-import { usePostCouponMutation } from '../@queries/coupon';
 import { useGetUserProfile } from '../@queries/profile';
 import useModal from '../useModal';
 import { COUPON_MESSEGE_MAX_LENGTH, COUPON_TITLE_MAX_LENGTH } from './../../constants/coupon';
-import useOnSuccess from './../useOnSuccess';
 
 const useEnterCouponContent = () => {
-  const { successNavigate } = useOnSuccess();
   const navigate = useNavigate();
 
   const [title, setTitle] = useState('');
@@ -20,30 +17,10 @@ const useEnterCouponContent = () => {
   const [couponType, setCouponType] = useState<CouponTransmitableType>('coffee');
   const checkedUsers = useRecoilValue<UserProfile[]>(checkedUsersAtom);
 
-  const { data: userProfile } = useGetUserProfile();
+  const { data: userProfile, isLoading } = useGetUserProfile();
 
   const isFilled = !!title.trim() && !!message.trim();
   const { close } = useModal();
-  const { mutate: sendCoupon } = usePostCouponMutation(
-    {
-      receiverIds: checkedUsers.map(user => user.id),
-      content: { couponType, title, message },
-    },
-    {
-      onSuccess: () => {
-        successNavigate({
-          page: ROUTE_PATH.ENTER_COUPON_CONTENT,
-          props: {
-            couponType,
-            message,
-            receivers: checkedUsers,
-            title,
-          },
-        });
-        close();
-      },
-    }
-  );
 
   const handleOnchangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
     const targetValue = e.target.value;
@@ -66,7 +43,6 @@ const useEnterCouponContent = () => {
     couponType,
     setCouponType,
     isFilled,
-    sendCoupon,
     title,
     message,
     setTitle,

--- a/frontend/src/hooks/Hearts/useHeartsMembers.tsx
+++ b/frontend/src/hooks/Hearts/useHeartsMembers.tsx
@@ -1,0 +1,18 @@
+import { useGetHearts } from '../@queries/hearts';
+import { useGetMembers } from '../@queries/members';
+import { usePostHeartMutation } from './../@queries/hearts';
+import useFilterMatchedUser from './../useFilterMatchedUser';
+
+const useHeartsMembers = (searchKeyword: string) => {
+  const { data: members } = useGetMembers(); //userList 전체 받아오기
+  const { data: heartHistory } = useGetHearts(); //
+  const { mutate: postHeart } = usePostHeartMutation();
+
+  const matchedUsers = useFilterMatchedUser(searchKeyword, members);
+  const sentMembers = heartHistory?.sent!;
+  const receivedMembers = heartHistory?.received!;
+
+  return { matchedUsers, sentMembers, receivedMembers, postHeart };
+};
+
+export default useHeartsMembers;

--- a/frontend/src/hooks/Main/useGridViewCoupons.ts
+++ b/frontend/src/hooks/Main/useGridViewCoupons.ts
@@ -1,0 +1,44 @@
+import { CouponStatusPriority, UserCanSeeCoupons } from '../../types/coupon';
+import { sorted } from '../../utils';
+import { useGetCoupons } from '../@queries/coupon';
+
+//낮을 수록 우선순위가 높다
+const COUPON_STATUS_PRIORITY: CouponStatusPriority = {
+  reserved: 0,
+  reserving: 1,
+  not_used: 2,
+};
+
+//TODO 해당하는 status가 없더라도 에러가 나지 않고 있다.
+const userCanSeeCouponsStatus: UserCanSeeCoupons[] = ['not_used', 'reserved', 'reserving'];
+
+const useGridViewCoupons = (currentType, sentOrReceived, showUsedCouponsWith) => {
+  const { data: coupons, isLoading, error } = useGetCoupons(sentOrReceived);
+
+  const couponsEditedByTransmitStatus =
+    sentOrReceived === 'sent'
+      ? coupons?.map(coupon => {
+          const [receiver, sender] = [coupon.sender, coupon.receiver];
+
+          return { ...coupon, receiver, sender };
+        })
+      : coupons;
+
+  const userCanSeeCoupons = couponsEditedByTransmitStatus
+    ?.filter(coupon => coupon.content.couponType === currentType || currentType === 'entire')
+    .filter(coupon =>
+      !showUsedCouponsWith ? userCanSeeCouponsStatus.some(status => status === coupon.status) : true
+    );
+
+  const sortedUserCanSeeCoupons = sorted(
+    userCanSeeCoupons,
+    (coupon1, coupon2) =>
+      COUPON_STATUS_PRIORITY[coupon1.status] - COUPON_STATUS_PRIORITY[coupon2.status]
+  );
+
+  return {
+    coupons: showUsedCouponsWith ? userCanSeeCoupons : sortedUserCanSeeCoupons,
+  };
+};
+
+export default useGridViewCoupons;

--- a/frontend/src/hooks/Main/useMain.ts
+++ b/frontend/src/hooks/Main/useMain.ts
@@ -1,58 +1,20 @@
 import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { sentOrReceivedAtom } from '../../recoil/atom';
-import { CouponStatusPriority, CouponType, UserCanSeeCoupons } from '../../types/coupon';
-import { sorted } from '../../utils';
-import { useGetCoupons } from '../@queries/coupon';
-
-//낮을 수록 우선순위가 높다
-const COUPON_STATUS_PRIORITY: CouponStatusPriority = {
-  reserved: 0,
-  reserving: 1,
-  not_used: 2,
-};
-
-//TODO 해당하는 status가 없더라도 에러가 나지 않고 있다.
-const userCanSeeCouponsStatus: UserCanSeeCoupons[] = ['not_used', 'reserved', 'reserving'];
+import { CouponType } from '../../types/coupon';
 
 const useMain = () => {
   const [sentOrReceived, setSentOrReceived] = useRecoilState(sentOrReceivedAtom);
   const [currentType, setCurrentType] = useState<CouponType>('entire');
   const [showUsedCouponsWith, setShowUsedCouponsWith] = useState(false);
 
-  const { data: coupons, isLoading, error } = useGetCoupons(sentOrReceived);
-
-  const couponsEditedByTransmitStatus =
-    sentOrReceived === 'sent'
-      ? coupons?.map(coupon => {
-          const [receiver, sender] = [coupon.sender, coupon.receiver];
-
-          return { ...coupon, receiver, sender };
-        })
-      : coupons;
-
-  const userCanSeeCoupons = couponsEditedByTransmitStatus
-    ?.filter(coupon => coupon.content.couponType === currentType || currentType === 'entire')
-    .filter(coupon =>
-      !showUsedCouponsWith ? userCanSeeCouponsStatus.some(status => status === coupon.status) : true
-    );
-
-  const sortedUserCanSeeCoupons = sorted(
-    userCanSeeCoupons,
-    (coupon1, coupon2) =>
-      COUPON_STATUS_PRIORITY[coupon1.status] - COUPON_STATUS_PRIORITY[coupon2.status]
-  );
-
   return {
-    setCurrentType,
-    coupons: showUsedCouponsWith ? userCanSeeCoupons : sortedUserCanSeeCoupons,
-    isLoading,
-    error,
     currentType,
     sentOrReceived,
+    showUsedCouponsWith,
+    setCurrentType,
     setSentOrReceived,
     setShowUsedCouponsWith,
-    showUsedCouponsWith,
   };
 };
 

--- a/frontend/src/hooks/Profile/useUserProfile.ts
+++ b/frontend/src/hooks/Profile/useUserProfile.ts
@@ -1,6 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQueryClient } from 'react-query';
-import { UserProfile } from '../../types/user';
 import {
   PROFILE_QUERY_KEY,
   useGetCouponExchangeCount,
@@ -10,16 +9,18 @@ import {
 import useToast from '../useToast';
 
 const useUserProfile = () => {
-  const { insertToastItem } = useToast();
   const queryClient = useQueryClient();
   const [isNameEdit, setIsNameEdit] = useState(false);
   const [name, setName] = useState<string>('');
 
-  const { data: profile } = useGetUserProfile({
-    onSuccess: (data: UserProfile) => {
-      setName(data.name);
-    },
-  });
+  const { insertToastItem } = useToast();
+  const { data: profile } = useGetUserProfile();
+
+  useEffect(() => {
+    if (profile) {
+      setName(profile?.name);
+    }
+  }, [profile]);
 
   const { data: exchangeCount } = useGetCouponExchangeCount();
 

--- a/frontend/src/hooks/Reservations/useListReservationItem.ts
+++ b/frontend/src/hooks/Reservations/useListReservationItem.ts
@@ -8,12 +8,12 @@ import {
 import { 예약요청응답별코멘트 } from '../Main/useCouponDetail';
 import useToast from '../useToast';
 
-type useReservationParam = {
+type useListReservationItemProps = {
   reservationId: number;
   time: MeetingTime;
 };
 
-const useReservation = ({ reservationId, time }: useReservationParam) => {
+const useListReservationItem = ({ reservationId, time }: useListReservationItemProps) => {
   const queryClient = useQueryClient();
   const { insertToastItem } = useToast();
 
@@ -61,4 +61,4 @@ const useReservation = ({ reservationId, time }: useReservationParam) => {
 
   return { handleClickOption };
 };
-export default useReservation;
+export default useListReservationItem;

--- a/frontend/src/hooks/Reservations/useListViewReservations.ts
+++ b/frontend/src/hooks/Reservations/useListViewReservations.ts
@@ -1,0 +1,10 @@
+import { useGetReservations } from './../@queries/reservation';
+import { ReservationOrderType } from './useReservations';
+
+const useListViewReservations = (orderBy: ReservationOrderType) => {
+  const { data: reservations } = useGetReservations(orderBy);
+
+  return { reservations };
+};
+
+export default useListViewReservations;

--- a/frontend/src/hooks/Reservations/useReservations.ts
+++ b/frontend/src/hooks/Reservations/useReservations.ts
@@ -1,18 +1,15 @@
 import { useRecoilState } from 'recoil';
 import { ReservationNavAtom } from '../../recoil/atom';
-import { useGetReservations } from '../@queries/reservation';
 
-type ReservationOrderType = 'sent' | 'received';
+export type ReservationOrderType = 'sent' | 'received';
 
-const useResrvations = () => {
+const useReservations = () => {
   const [orderBy, setOrderBy] = useRecoilState<ReservationOrderType>(ReservationNavAtom);
-  const { data: reservations } = useGetReservations(orderBy);
 
   return {
     orderBy,
     setOrderBy,
-    reservations,
   };
 };
 
-export default useResrvations;
+export default useReservations;

--- a/frontend/src/hooks/SelectReceiver/useListViewUsers.ts
+++ b/frontend/src/hooks/SelectReceiver/useListViewUsers.ts
@@ -1,0 +1,12 @@
+import { useGetMembers } from '../@queries/members';
+import useFilterMatchedUser from './../useFilterMatchedUser';
+
+const useListViewUsers = (searchKeyword: string) => {
+  const { data: members } = useGetMembers();
+
+  const matchedUsers = useFilterMatchedUser(searchKeyword, members);
+
+  return { matchedUsers };
+};
+
+export default useListViewUsers;

--- a/frontend/src/hooks/SelectReceiver/useSelectReceiver.ts
+++ b/frontend/src/hooks/SelectReceiver/useSelectReceiver.ts
@@ -2,12 +2,9 @@ import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { checkedUsersAtom } from '../../recoil/atom';
 import { UserProfile } from '../../types/user';
-import { useGetMembers } from '../@queries/members';
-import useFilterMatchedUser from '../useFilterMatchedUser';
 
 const useSelectReceiver = () => {
   const [keyword, setKeyword] = useState('');
-  const { data: members, isLoading, error } = useGetMembers();
   const [checkedUsers, setCheckedUsers] = useRecoilState<UserProfile[]>(checkedUsersAtom);
 
   const checkUser = (user: UserProfile) => {
@@ -27,19 +24,13 @@ const useSelectReceiver = () => {
   const isCheckedUser = (user: UserProfile) =>
     checkedUsers?.some(checkUser => checkUser.id === user.id);
 
-  const matchedUsers = useFilterMatchedUser(keyword, members);
-
   return {
-    members,
-    isLoading,
-    error,
     checkedUsers,
     toggleUser,
     uncheckUser,
     isCheckedUser,
     keyword,
     setKeyword,
-    matchedUsers,
   };
 };
 

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -10,6 +10,8 @@ import { ReactQueryDevtools } from 'react-query/devtools';
 import { RecoilRoot } from 'recoil';
 import { queryClient } from './apis/queryClient';
 import './assets/favicon/favicon.ico';
+import CustomErrorBoundary from './errors/CustomErrorBoundary';
+import ErrorFallBack from './errors/ErrorFallBack';
 import reset from './styles/GlobalReset';
 import global from './styles/GlobalStyled';
 import { ThemeProvider } from './styles/ThemeProvider';
@@ -29,7 +31,9 @@ root.render(
       <QueryClientProvider client={queryClient}>
         <RecoilRoot>
           <ThemeProvider>
-            <App />
+            <CustomErrorBoundary fallbackComponent={ErrorFallBack}>
+              <App />
+            </CustomErrorBoundary>
           </ThemeProvider>
         </RecoilRoot>
         <ReactQueryDevtools />

--- a/frontend/src/pages/EnterCouponContent.tsx
+++ b/frontend/src/pages/EnterCouponContent.tsx
@@ -6,13 +6,13 @@ import TabsNav from '../components/@shared/TabsNav';
 import useEnterCouponContent from '../hooks/EnterCouponContent/useEnterCouponContent';
 
 import CouponLayout from '../components/@shared/CouponLayout';
-import Header from '../layout/Header';
-import PageLayout from '../layout/PageLayout';
-import ConfirmCouponContentModal from '../components/EnterCouponContent/ConfirmCouponContentModal';
-import HeaderText from '../layout/HeaderText';
-import { couponTypeKeys, couponTypes } from '../types/coupon';
 import LongButton from '../components/@shared/LongButton';
 import ModalWrapper from '../components/@shared/Modal/ModalWrapper';
+import ConfirmCouponContentModal from '../components/EnterCouponContent/ConfirmCouponContentModal';
+import Header from '../layout/Header';
+import HeaderText from '../layout/HeaderText';
+import PageLayout from '../layout/PageLayout';
+import { couponTypeKeys, couponTypes } from '../types/coupon';
 
 const couponTypesWithoutEntire = couponTypeKeys.filter(type => type !== 'entire');
 
@@ -26,7 +26,6 @@ const EnterCouponContent = () => {
     checkedUsers,
     currentUserId,
     currentUserName,
-    sendCoupon,
     handleOnchangeMessage,
     handleOnchangeTitle,
   } = useEnterCouponContent();
@@ -76,7 +75,6 @@ const EnterCouponContent = () => {
               title={title}
               message={message}
               receivers={checkedUsers}
-              submit={sendCoupon}
               couponType={couponType}
             />
           }

--- a/frontend/src/pages/Hearts.tsx
+++ b/frontend/src/pages/Hearts.tsx
@@ -1,27 +1,15 @@
 import styled from '@emotion/styled';
-import { FlexCenter } from '../styles/mixIn';
-import { BASE_URL } from './../constants/api';
-import { useGetHearts, usePostHeartMutation } from './../hooks/@queries/hearts';
-import { useGetMembers } from './../hooks/@queries/members';
+import { Suspense, useState } from 'react';
+import Members from '../components/Hearts/Members';
 import UserSearchInput from '../components/SelectReceiver/UserSearchInput';
-import { useState } from 'react';
-import useFilterMatchedUser from '../hooks/useFilterMatchedUser';
+import CustomErrorBoundary from '../errors/CustomErrorBoundary';
+import ErrorFallBack from '../errors/ErrorFallBack';
 import HeaderText from '../layout/HeaderText';
 import MainPageLayout from '../layout/MainPageLayout';
+import Spinner from './../components/@shared/Spinner';
 
 const Hearts = () => {
   const [keyword, setKeyword] = useState('');
-  const { data: members, isLoading: isMemberLoading, isError: isMemberError } = useGetMembers(); //userList 전체 받아오기
-  const matchedUsers = useFilterMatchedUser(keyword, members);
-  const { data: heartHistory, isLoading: isHeartLoading, isError: isHeartError } = useGetHearts(); //
-  const { mutate: postHeart } = usePostHeartMutation();
-
-  //sent를 돌면서 sent에 있는 receiver들은 못 보내는 애들
-  // received에 있는 sender들은 보낼 수 있는 애들
-  if (isHeartLoading) return <></>;
-
-  const sent = heartHistory?.sent!;
-  const received = heartHistory?.received!;
 
   return (
     <MainPageLayout>
@@ -30,57 +18,15 @@ const Hearts = () => {
         <S.InputWrapper>
           <UserSearchInput value={keyword} setKeyword={setKeyword} />
         </S.InputWrapper>
-        <S.MembersContainer>
-          {matchedUsers?.map(user => {
-            const canSend =
-              !sent?.some(sentHistory => sentHistory.receiverId === user.id) ||
-              received?.some(receivedHistory => receivedHistory.senderId === user.id);
-
-            const count = sent?.find(sentHistory => sentHistory.receiverId === user.id)?.count;
-            const lastReceived =
-              sent?.find(sentHistory => sentHistory.receiverId === user.id)?.modifiedAt ||
-              received?.find(receiveHistory => receiveHistory.senderId === user.id)?.modifiedAt;
-            const modifiedLastReceived = lastReceived?.split(' ')[0];
-            const receivedUserCount = received?.find(
-              receiveHistory => receiveHistory.senderId === user.id
-            )?.count;
-
-            return (
-              <S.UserWrappr key={user.id}>
-                <S.UserImageWrapper>
-                  <S.UserImage src={`${BASE_URL}${user.imageUrl}`} />
-                </S.UserImageWrapper>
-                <S.UserName>{user.name}</S.UserName>
-                {modifiedLastReceived && (
-                  <S.ModifiedAt>{`${modifiedLastReceived}에 콕!`}</S.ModifiedAt>
-                )}
-
-                <S.CountWrapper>
-                  <S.CountLabel>연속</S.CountLabel>{' '}
-                  <S.CountNum>{`${count || receivedUserCount || 0}회`}</S.CountNum>
-                </S.CountWrapper>
-                <S.SendButtonWrapper>
-                  <S.SendButton
-                    canSend={canSend}
-                    onClick={() => {
-                      if (canSend) {
-                        postHeart(user.id);
-                      }
-                    }}
-                  >
-                    콕
-                  </S.SendButton>
-                </S.SendButtonWrapper>
-              </S.UserWrappr>
-            );
-          })}
-        </S.MembersContainer>
+        <CustomErrorBoundary fallbackComponent={ErrorFallBack}>
+          <Suspense fallback={<Spinner />}>
+            <Members searchKeyword={keyword} />
+          </Suspense>
+        </CustomErrorBoundary>
       </S.Body>
     </MainPageLayout>
   );
 };
-
-type CheckBoxProp = { canSend: boolean };
 
 const S = {
   Header: styled(HeaderText)`
@@ -90,100 +36,8 @@ const S = {
   Body: styled.div`
     height: calc(80%);
   `,
-  MembersContainer: styled.div`
-    width: 100%;
-
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1rem;
-
-    overflow: auto;
-    height: calc(100% - 5rem);
-    padding-bottom: 17rem;
-  `,
   InputWrapper: styled.div`
     margin-bottom: 1.5rem;
-  `,
-  UserWrappr: styled.div`
-    width: 99.5%;
-    height: 5rem;
-    display: grid;
-    grid-template-areas:
-      'ui un ct cb'
-      'ui sn ct cb';
-    grid-template-columns: 17% 50% 13% 20%;
-    grid-template-rows: 60% 40%;
-    border-radius: 5px;
-    gap: 2px 0;
-  `,
-  UserImageWrapper: styled.div`
-    grid-area: ui;
-    width: 100%;
-    height: 100%;
-    ${FlexCenter};
-  `,
-
-  UserImage: styled.img`
-    width: 30px;
-
-    border-radius: 50%;
-    object-fit: cover;
-  `,
-  UserName: styled.span`
-    grid-area: un;
-    height: 100%;
-    line-height: 3.5rem;
-    font-size: 16px;
-    color: ${({ theme }) => theme.page.color};
-  `,
-  ModifiedAt: styled.div`
-    grid-area: sn;
-    height: 100%;
-    font-size: 1.3rem;
-    color: ${({ theme }) => theme.page.subColor};
-  `,
-  CountWrapper: styled.div`
-    grid-area: ct;
-    display: flex;
-    flex-direction: column;
-    color: ${({ theme }) => theme.page.color};
-    padding: 0.6rem 0;
-    text-align: center;
-    gap: 3px;
-    justify-content: center;
-  `,
-  CountLabel: styled.div`
-    color: #c9c9c9;
-    font-size: 1rem;
-  `,
-  CountNum: styled.div`
-    color: mediumspringgreen; //10회 미만 darksalmon 10회 이상 mediumspringgreen 30회 이상 fuchsia 100회 이상 gold
-    font-size: 1.5rem;
-  `,
-  SendButtonWrapper: styled.div`
-    grid-area: cb;
-    ${FlexCenter}
-    margin-right: 5px;
-    align-items: center;
-    width: 100%;
-    height: 100%;
-  `,
-  SendButton: styled.span<CheckBoxProp>`
-    display: grid;
-    place-items: center;
-
-    width: 80%;
-    height: 80%;
-    border-radius: 8px;
-
-    text-align: center;
-    background-color: ${({ canSend }) => (canSend ? `#ff7a62` : `#adadad`)};
-    font-size: 1.3rem;
-    line-height: 3rem;
-
-    color: ${({ canSend }) => (canSend ? 'white' : '#7a7a7a')};
-    cursor: ${({ canSend }) => (canSend ? 'pointer' : '')};
   `,
 };
 

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -5,33 +5,32 @@ import TabsNav from '../components/@shared/TabsNav';
 import GridViewCoupons from '../components/Main/GridViewCoupons';
 
 import { css } from '@emotion/react';
+import { Suspense } from 'react';
 import { Link } from 'react-router-dom';
-import NoReceivedCoupon from './../components/@shared/noContent/NoReceivedCoupon';
-import NoSendCoupon from './../components/@shared/noContent/NoSendCoupon';
+import Spinner from '../components/@shared/Spinner';
+import CustomErrorBoundary from '../errors/CustomErrorBoundary';
 import useMain from '../hooks/Main/useMain';
+import useQRCoupon from '../hooks/useQRCoupon';
 import HeaderText from '../layout/HeaderText';
 import MainPageLayout from '../layout/MainPageLayout';
-import useQRCoupon from '../hooks/useQRCoupon';
-import Spinner from '../components/@shared/Spinner';
 import { couponTypeKeys, couponTypes } from '../types/coupon';
 
 const sentOrReceivedArray = ['received', 'sent'];
 
+const ErrorFallback = () => {
+  return <ErrorFallBack.Wrapper>에러발생!</ErrorFallBack.Wrapper>;
+};
+
 const Main = () => {
   const {
-    setCurrentType,
-    coupons,
-    isLoading,
-    error,
     currentType,
     sentOrReceived,
-    setSentOrReceived,
     showUsedCouponsWith,
+    setCurrentType,
+    setSentOrReceived,
     setShowUsedCouponsWith,
   } = useMain();
   useQRCoupon();
-
-  if (error) return <div>에러뜸</div>;
 
   return (
     <MainPageLayout>
@@ -76,19 +75,20 @@ const Main = () => {
             </S.UsedCouponCheckboxLabel>
           </S.UsedCouponToggleForm>
         </S.TabsNavWrapper>
-        {isLoading ? (
-          <Spinner />
-        ) : coupons?.length ? (
-          <GridViewCoupons coupons={coupons} />
-        ) : sentOrReceived === 'sent' ? (
-          <NoSendCoupon />
-        ) : (
-          <NoReceivedCoupon />
-        )}
+        <CustomErrorBoundary fallbackComponent={ErrorFallback}>
+          <Suspense fallback={<Spinner />}>
+            <GridViewCoupons
+              currentType={currentType}
+              sentOrReceived={sentOrReceived}
+              showUsedCouponsWith={showUsedCouponsWith}
+            />
+          </Suspense>
+        </CustomErrorBoundary>
       </S.Body>
     </MainPageLayout>
   );
 };
+
 type SliderDivProps = {
   length: number;
   current: number;
@@ -188,4 +188,9 @@ const S = {
   `,
 };
 
+const ErrorFallBack = {
+  Wrapper: styled.div`
+    color: white;
+  `,
+};
 export default Main;

--- a/frontend/src/pages/Main.tsx
+++ b/frontend/src/pages/Main.tsx
@@ -9,6 +9,7 @@ import { Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import Spinner from '../components/@shared/Spinner';
 import CustomErrorBoundary from '../errors/CustomErrorBoundary';
+import ErrorFallBack from '../errors/ErrorFallBack';
 import useMain from '../hooks/Main/useMain';
 import useQRCoupon from '../hooks/useQRCoupon';
 import HeaderText from '../layout/HeaderText';
@@ -16,10 +17,6 @@ import MainPageLayout from '../layout/MainPageLayout';
 import { couponTypeKeys, couponTypes } from '../types/coupon';
 
 const sentOrReceivedArray = ['received', 'sent'];
-
-const ErrorFallback = () => {
-  return <ErrorFallBack.Wrapper>에러발생!</ErrorFallBack.Wrapper>;
-};
 
 const Main = () => {
   const {
@@ -75,7 +72,7 @@ const Main = () => {
             </S.UsedCouponCheckboxLabel>
           </S.UsedCouponToggleForm>
         </S.TabsNavWrapper>
-        <CustomErrorBoundary fallbackComponent={ErrorFallback}>
+        <CustomErrorBoundary fallbackComponent={ErrorFallBack}>
           <Suspense fallback={<Spinner />}>
             <GridViewCoupons
               currentType={currentType}
@@ -188,9 +185,4 @@ const S = {
   `,
 };
 
-const ErrorFallBack = {
-  Wrapper: styled.div`
-    color: white;
-  `,
-};
 export default Main;

--- a/frontend/src/pages/Meetings.tsx
+++ b/frontend/src/pages/Meetings.tsx
@@ -1,118 +1,20 @@
-import styled from '@emotion/styled';
-import HeaderText from '../layout/HeaderText';
+import { Suspense } from 'react';
+import CustomErrorBoundary from '../errors/CustomErrorBoundary';
+import ErrorFallBack from '../errors/ErrorFallBack';
 import MainPageLayout from '../layout/MainPageLayout';
-import { COUPON_IMAGE } from '../constants/coupon';
-import useMeetings from '../hooks/Meetings/useMeetings';
-import NoMeeting from './../components/@shared/noContent/NoMeeting';
-import ConditionalViewer from '../components/@shared/ConditionalViewer';
+import Spinner from './../components/@shared/Spinner';
+import ListViewMeetings from './../components/Meeting/ListViewMeetings';
 
 const Meetings = () => {
-  const { meetings, meetingDateAnnouncement } = useMeetings();
-
   return (
     <MainPageLayout>
-      <S.HeaderText>{meetingDateAnnouncement}</S.HeaderText>
-      <S.Body>
-        <ConditionalViewer condition={meetings?.length !== 0} replacement={<NoMeeting />}>
-          {meetings?.map((meeting, idx) => (
-            <S.Meeting isToday={meeting.isMeetingToday} key={idx}>
-              {meeting.isMeetingToday && <S.TodayStrap>오늘</S.TodayStrap>}
-              <S.CouponImageWrapper>
-                <S.CouponTypeImage src={COUPON_IMAGE[meeting.couponType]} />
-              </S.CouponImageWrapper>
-              <S.MeetingDetail>
-                <S.DetailWrapper>
-                  <S.Label>만날 사람</S.Label>
-                  <span>{meeting.memberName}</span>
-                </S.DetailWrapper>
-                <S.DateWrapper>
-                  <S.DetailWrapper>
-                    <S.Label>날짜</S.Label>
-                    <span>{meeting.meetingDate}</span>
-                  </S.DetailWrapper>
-                  <S.DetailWrapper>
-                    <S.Label>시간</S.Label>
-                    <span>{meeting.meetingTime}</span>
-                  </S.DetailWrapper>
-                </S.DateWrapper>
-              </S.MeetingDetail>
-            </S.Meeting>
-          ))}
-        </ConditionalViewer>
-      </S.Body>
+      <CustomErrorBoundary fallbackComponent={ErrorFallBack}>
+        <Suspense fallback={<Spinner />}>
+          <ListViewMeetings />
+        </Suspense>
+      </CustomErrorBoundary>
     </MainPageLayout>
   );
 };
 
 export default Meetings;
-
-type MeetingWrapperProps = {
-  isToday: boolean;
-};
-
-const S = {
-  HeaderText: styled(HeaderText)`
-    color: white;
-  `,
-  Body: styled.section`
-    display: block;
-    flex-direction: column;
-    gap: 1rem;
-    height: 100%;
-    overflow: auto;
-  `,
-  Meeting: styled.div<MeetingWrapperProps>`
-    position: relative;
-    width: 100%;
-    color: white;
-    border-radius: 4px;
-    display: flex;
-    gap: 20px;
-    box-sizing: border-box;
-    align-items: center;
-    padding: 10px;
-    background-color: #4a4a4a;
-    border: ${({ theme, isToday }) => (isToday ? '2px solid tomato' : 'unset')};
-    overflow: hidden;
-    font-size: 1.5rem;
-    margin: 10px 0;
-  `,
-  TodayStrap: styled.span`
-    position: absolute;
-    font-size: 15px;
-    top: 7px;
-    right: -20px;
-    padding: 5px 30px;
-    background-color: ${({ theme }) => theme.primary};
-    color: white;
-    transform: rotate(40deg);
-  `,
-  MeetingDetail: styled.div`
-    width: 100%;
-    display: flex;
-    flex-flow: column;
-    gap: 5px;
-  `,
-  DetailWrapper: styled.div`
-    display: flex;
-    flex-flow: column;
-    gap: 3px;
-  `,
-  CouponImageWrapper: styled.div`
-    width: 65px;
-    display: flex;
-    justify-content: center;
-  `,
-  CouponTypeImage: styled.img`
-    width: 40px;
-    object-fit: cover;
-  `,
-  Label: styled.span`
-    color: #838383;
-    font-size: 12px;
-  `,
-  DateWrapper: styled.div`
-    display: flex;
-    justify-content: space-between;
-  `,
-};

--- a/frontend/src/pages/Reservations.tsx
+++ b/frontend/src/pages/Reservations.tsx
@@ -1,15 +1,18 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import HeaderText from '../layout/HeaderText';
-import Reservation from '../components/Reservations/Reservation';
+import { Suspense } from 'react';
 import useReservations from '../hooks/Reservations/useReservations';
-import NoReservation from '../components/@shared/noContent/NoReservation';
+import HeaderText from '../layout/HeaderText';
 import MainPageLayout from '../layout/MainPageLayout';
+import Spinner from './../components/@shared/Spinner';
+import ListViewReservations from './../components/Reservations/ListViewReservations';
+import CustomErrorBoundary from './../errors/CustomErrorBoundary';
+import ErrorFallBack from './../errors/ErrorFallBack';
 
 const ReservationNav = ['received', 'sent'];
 
 const Reservations = () => {
-  const { reservations, orderBy, setOrderBy } = useReservations();
+  const { orderBy, setOrderBy } = useReservations();
 
   return (
     <MainPageLayout>
@@ -33,19 +36,11 @@ const Reservations = () => {
         </S.CouponStatusNav>
       </S.CouponStatusNavWrapper>
       <S.Body>
-        <S.ListView>
-          {reservations?.length > 0 ? (
-            reservations.map(reservation => (
-              <Reservation
-                key={reservation.reservationId}
-                transmitStatus={orderBy}
-                {...reservation}
-              />
-            ))
-          ) : (
-            <NoReservation />
-          )}
-        </S.ListView>
+        <CustomErrorBoundary fallbackComponent={ErrorFallBack}>
+          <Suspense fallback={<Spinner />}>
+            <ListViewReservations orderBy={orderBy} />
+          </Suspense>
+        </CustomErrorBoundary>
       </S.Body>
     </MainPageLayout>
   );
@@ -70,13 +65,6 @@ const S = {
     padding: 5px 0;
     color: white;
     gap: 15px;
-  `,
-  ListView: styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    height: 70vh;
-    overflow: auto;
   `,
   CouponStatusNavWrapper: styled.div`
     position: relative;

--- a/frontend/src/pages/SelectReceiver.tsx
+++ b/frontend/src/pages/SelectReceiver.tsx
@@ -7,24 +7,18 @@ import ListViewUsers from '../components/SelectReceiver/ListViewUsers';
 import UserSearchInput from '../components/SelectReceiver/UserSearchInput';
 import useSelectReceiver from '../hooks/SelectReceiver/useSelectReceiver';
 
+import { Suspense } from 'react';
+import LongButton from '../components/@shared/LongButton';
 import { ROUTE_PATH } from '../constants/routes';
 import HeaderText from '../layout/HeaderText';
 import MainPageLayout from '../layout/MainPageLayout';
-import LongButton from '../components/@shared/LongButton';
+import Spinner from './../components/@shared/Spinner';
+import CustomErrorBoundary from './../errors/CustomErrorBoundary';
+import ErrorFallBack from './../errors/ErrorFallBack';
 
 const SelectReceiver = () => {
-  const {
-    members,
-    isLoading,
-    error,
-    checkedUsers,
-    toggleUser,
-    uncheckUser,
-    isCheckedUser,
-    keyword,
-    setKeyword,
-    matchedUsers,
-  } = useSelectReceiver();
+  const { checkedUsers, toggleUser, uncheckUser, isCheckedUser, keyword, setKeyword } =
+    useSelectReceiver();
 
   return (
     <MainPageLayout>
@@ -37,13 +31,15 @@ const SelectReceiver = () => {
           <UserSearchInput value={keyword} setKeyword={setKeyword} />
         </S.InputWrapper>
         <S.Section isShowUser={!!checkedUsers?.length}>
-          {members && (
-            <ListViewUsers
-              users={matchedUsers}
-              isCheckedUser={isCheckedUser}
-              onClickUser={toggleUser}
-            />
-          )}
+          <CustomErrorBoundary fallbackComponent={ErrorFallBack}>
+            <Suspense fallback={<Spinner />}>
+              <ListViewUsers
+                searchKeyword={keyword}
+                isCheckedUser={isCheckedUser}
+                onClickUser={toggleUser}
+              />
+            </Suspense>
+          </CustomErrorBoundary>
           <S.SendButtonBox>
             <S.ButtonLink to={checkedUsers.length ? `${ROUTE_PATH.ENTER_COUPON_CONTENT}` : '#'}>
               <LongButton isDisabled={!checkedUsers.length}>

--- a/frontend/src/pages/UserProfile.tsx
+++ b/frontend/src/pages/UserProfile.tsx
@@ -1,19 +1,17 @@
 import styled from '@emotion/styled';
+import { Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import ArrowBackButton from '../components/@shared/ArrowBackButton';
-import Header from '../layout/Header';
-import Input from '../components/@shared/Input';
-import PageLayout from '../layout/PageLayout';
-import ProfileUserImage from '../components/Profile/ProfileUserImage';
 import SignOutButton from '../components/Profile/SignOutButton';
-import useUserProfile from '../hooks/Profile/useUserProfile';
-import { USER_NICKNAME_MAX_LENGTH } from './../constants/users';
+import CustomErrorBoundary from '../errors/CustomErrorBoundary';
+import Header from '../layout/Header';
 import HeaderText from '../layout/HeaderText';
+import PageLayout from '../layout/PageLayout';
+import Spinner from './../components/@shared/Spinner';
+import ProfileInfo from './../components/Profile/ProfileInfo';
+import ErrorFallBack from './../errors/ErrorFallBack';
 
 const UserProfile = () => {
-  const { profile, isNameEdit, name, handleClickModifyNameButton, exchangeCount, setName } =
-    useUserProfile();
-
   return (
     <PageLayout>
       <Header>
@@ -25,47 +23,11 @@ const UserProfile = () => {
           <SignOutButton />
         </S.SubHeader>
       </Header>
-      <S.Body>
-        <ProfileUserImage src={profile ? profile?.imageUrl : 'default'} />
-        <S.UserInfoBox>
-          <S.UserInfoItem>
-            <S.Bold>이름</S.Bold>
-            {isNameEdit ? (
-              <Input
-                type='text'
-                value={name}
-                setValue={setName}
-                placeholder='이름을 입력해주세요'
-                onKeyDown={e => {
-                  if (e.code === 'Enter') {
-                    handleClickModifyNameButton();
-                  }
-                }}
-                maxLength={USER_NICKNAME_MAX_LENGTH}
-              />
-            ) : (
-              <span>{name}</span>
-            )}
-            <S.ModifyNameButton onClick={handleClickModifyNameButton}>
-              {isNameEdit ? '저장' : '수정'}
-            </S.ModifyNameButton>
-          </S.UserInfoItem>
-          <S.UserInfoItem>
-            <S.Bold>이메일</S.Bold>
-            <span>{profile?.email}</span>
-          </S.UserInfoItem>
-        </S.UserInfoBox>
-        <S.UserCouponInfo>
-          <S.UserCouponInfoItem>
-            <span>보낸 쿠폰 수</span>
-            <span>{exchangeCount?.sentCount}</span>
-          </S.UserCouponInfoItem>
-          <S.UserCouponInfoItem>
-            <span>받은 쿠폰 수</span>
-            <span>{exchangeCount?.receivedCount}</span>
-          </S.UserCouponInfoItem>
-        </S.UserCouponInfo>
-      </S.Body>
+      <CustomErrorBoundary fallbackComponent={ErrorFallBack}>
+        <Suspense fallback={<Spinner />}>
+          <ProfileInfo />
+        </Suspense>
+      </CustomErrorBoundary>
     </PageLayout>
   );
 };
@@ -73,54 +35,6 @@ const UserProfile = () => {
 export default UserProfile;
 
 const S = {
-  Body: styled.div`
-    display: flex;
-    flex-direction: column;
-    height: 50%;
-    margin: 0 3vw;
-
-    span {
-      font-size: 1.6rem;
-    }
-  `,
-  UserInfoBox: styled.div`
-    display: flex;
-    flex-direction: column;
-    padding-bottom: 1.5rem;
-    gap: 1rem;
-    margin: 3rem 0 2rem;
-    border-bottom: ${({ theme }) => `1px solid ${theme.primary}`};
-  `,
-  UserInfoItem: styled.div`
-    display: grid;
-    grid-template-columns: 30% 50% 20%;
-    align-items: center;
-    color: white;
-    height: 40px;
-  `,
-  Bold: styled.span`
-    font-weight: 700;
-    font-size: 1.6rem;
-  `,
-  ModifyNameButton: styled.button`
-    background-color: transparent;
-    font-size: 1.6rem;
-    border: none;
-    font-weight: 600;
-    color: ${({ theme }) => theme.primary};
-    text-align: right;
-  `,
-  UserCouponInfo: styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: space-between;
-    gap: 2rem;
-  `,
-  UserCouponInfoItem: styled.div`
-    display: flex;
-    justify-content: space-between;
-    color: white;
-  `,
   SubHeader: styled.div`
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## 상세 내용
### Suspens, Errorboundary를 아래에 추가한다.
  - main
  - hearts
  - selectReceiver
  - coupon detail
  - reservation
  - meetings 
  - userProfile 
  - confirm coupon button

### suspense 적용 시 mount 순서 변경에 따른 error 수정한다
  - retry를 infinite에서 3회로 수정하였습니다.
  - reservation 페이지에서 mount 이전에 state를 호출하는 오류 수정
  - 날짜 계산을 잘 못하는 오류 수정
  - choice slider에서 mount 이전에 state를 호출하는 오류 수정

### 서스펜스에는 아래 디자인을 적용한다.
![서스펜스](https://user-images.githubusercontent.com/72348351/196694462-f623bf75-2514-4c3b-bd2f-db1db9acfe62.gif)

### 에러바운더리에는 아래 디자인을 적용한다.
![image](https://user-images.githubusercontent.com/72348351/196699583-bf0277fe-4bbf-4fc9-8b0b-ac8b445e863a.png)


### 리뷰 포인트
- 디자인에 관해서 윈도우에서는 확인했으나 맥에서 확인을 못했습니다. 확인부탁드립니다.
- 날짜를 올바르게 받지 못하는 에러에 대해서 윈도우에서는 확인했으나 맥에서 확인을 못했습니다. 확인부탁드립니다.
- Errorboundary 가 Suspense 보다 바깥에 있도록 작성하였습니다.
- ErrorBoundary 에서 refetch할 수 있도록 구현하였습니다. 현재는 모든 컴포넌트에서 refetch가 필요할 것이라고 판단하여, onClick bind를 이용하여 구현하였습니다.

### 생각보다 작업량이 많아서 File Change가 많습니다. 죄송합니다.

Close #586

