### PR TITLE
feat: 즉시사용인 경우 즉시 사용을 누른 시간을 보여주도록 변경

### DIFF
--- a/frontend/src/components/@shared/PageSlider.tsx
+++ b/frontend/src/components/@shared/PageSlider.tsx
@@ -91,6 +91,7 @@ const S = {
     border-radius: 50%;
     background-color: #8e8e8e;
     transition: all ease-in-out 0.1s;
+    cursor: pointer;
 
     &.active {
       width: 22px;

--- a/frontend/src/components/Main/CouponDetail.reservation.tsx
+++ b/frontend/src/components/Main/CouponDetail.reservation.tsx
@@ -4,15 +4,22 @@ import { Link } from 'react-router-dom';
 import { CouponDetail } from '../../types/coupon';
 import { BASE_URL } from './../../constants/api';
 
+const defaultRawTime = `2000-01-01 00:00:00`;
+
 const CouponDetailReserve = (
   { couponDetail }: { couponDetail: CouponDetail },
   ref: LegacyRef<HTMLDivElement>
 ) => {
   const { coupon, reservation, meeting } = couponDetail;
-  const { time: RawTime } = reservation ||
-    meeting || { time: { meetingTime: new Date().toLocaleString() } };
-  const date = RawTime?.meetingTime.split(' ')[0];
-  const time = RawTime?.meetingTime.split(' ')[1].slice(0, 5);
+
+  const RawTime =
+    reservation?.time?.meetingTime ||
+    meeting?.time.meetingTime ||
+    coupon.modifiedDateTime ||
+    defaultRawTime;
+
+  const date = RawTime?.split(' ')[0];
+  const time = RawTime?.split(' ')[1].slice(0, 5);
 
   return (
     <S.Contents ref={ref}>

--- a/frontend/src/components/Main/CouponDetail.reservation.tsx
+++ b/frontend/src/components/Main/CouponDetail.reservation.tsx
@@ -3,8 +3,9 @@ import { forwardRef, LegacyRef } from 'react';
 import { Link } from 'react-router-dom';
 import { CouponDetail } from '../../types/coupon';
 import { BASE_URL } from './../../constants/api';
+import { getNowKrLocaleFullDateISOFormat, serverDateFormmater } from './../../utils/date';
 
-const defaultRawTime = `2000-01-01 00:00:00`;
+const defaultRawTime = getNowKrLocaleFullDateISOFormat();
 
 const CouponDetailReserve = (
   { couponDetail }: { couponDetail: CouponDetail },
@@ -18,8 +19,7 @@ const CouponDetailReserve = (
     coupon.modifiedDateTime ||
     defaultRawTime;
 
-  const date = RawTime?.split(' ')[0];
-  const time = RawTime?.split(' ')[1].slice(0, 5);
+  const { date, time } = serverDateFormmater(RawTime);
 
   return (
     <S.Contents ref={ref}>

--- a/frontend/src/components/Main/GridViewCoupons.tsx
+++ b/frontend/src/components/Main/GridViewCoupons.tsx
@@ -103,7 +103,7 @@ const S = {
     overflow: hidden;
     position: relative;
     transition: all ease-in-out 0.1s;
-
+    cursor: pointer;
     :hover,
     :active {
       opacity: 0.8;

--- a/frontend/src/mocks/dummyData.ts
+++ b/frontend/src/mocks/dummyData.ts
@@ -118,6 +118,7 @@ export const dummyCoupons: Coupon[] = [
     },
     status: 'not_used',
     createdDate: '2022-12-20',
+    modifiedDateTime: '2022-10-20 04:24:19',
   },
   {
     couponId: 2,
@@ -134,6 +135,7 @@ export const dummyCoupons: Coupon[] = [
     },
     status: 'not_used',
     createdDate: '2022-12-20',
+    modifiedDateTime: '2022-10-20 04:24:19',
   },
   {
     couponId: 3,
@@ -150,6 +152,7 @@ export const dummyCoupons: Coupon[] = [
     },
     status: 'reserving',
     createdDate: '2022-12-20',
+    modifiedDateTime: '2022-10-20 04:24:19',
   },
   {
     couponId: 4,
@@ -166,6 +169,7 @@ export const dummyCoupons: Coupon[] = [
     },
     status: 'reserved',
     createdDate: '2022-09-20',
+    modifiedDateTime: '2022-10-20 04:24:19',
   },
   // {
   //   couponId: 5, // Number (coupon history id)

--- a/frontend/src/types/coupon.ts
+++ b/frontend/src/types/coupon.ts
@@ -19,6 +19,7 @@ export interface Coupon {
   content: CouponContent;
   status: CouponStatus;
   createdDate: YYYYMMDD;
+  modifiedDateTime: string;
 }
 export interface CouponDetail {
   coupon: Coupon;

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -10,8 +10,8 @@ export const engDayTo요일 = {
   Sun: '일',
 };
 
-const getNowKrLocaleFullDateISOFormat = () =>
-  new Date().toLocaleDateString() +
+export const getNowKrLocaleFullDateISOFormat = () =>
+  new Date().toLocaleDateString('ko-KR').replaceAll('. ', '-').replace('.', '') +
   ' ' +
   new Date()
     .toLocaleTimeString('ko-KR', { hour12: false })


### PR DESCRIPTION
## 상세 내용
- 즉시사용이 제대로 된 날짜를 보여주도록 변경한다.

### 변경 후
- 즉시사용 날짜 
![image](https://user-images.githubusercontent.com/72348351/196874035-82641a62-0103-4280-9b2b-b1c3cd2b46b4.png)

- 예약 후 사용완료 날짜
![image](https://user-images.githubusercontent.com/72348351/196874118-ecff77d8-c505-4d8e-a190-07c66c8e367f.png)

- 예약 완료 날짜
![image](https://user-images.githubusercontent.com/72348351/196874222-3806d816-2238-43e1-aab6-e8f2ef5022c7.png)


Close #592
