### PR TITLE
feat: 마음보내기 페이지의 정렬 순서를 변경한다

### DIFF
--- a/frontend/src/components/Hearts/Members.tsx
+++ b/frontend/src/components/Hearts/Members.tsx
@@ -4,51 +4,42 @@ import { FlexCenter } from '../../styles/mixIn';
 import { BASE_URL } from './../../constants/api';
 
 const Members = ({ searchKeyword }: { searchKeyword: string }) => {
-  const { matchedUsers, sentMembers, receivedMembers, postHeart } = useHeartsMembers(searchKeyword);
+  const { searchedUserWithState, postHeart } = useHeartsMembers(searchKeyword);
 
   return (
     <S.MembersContainer>
-      {matchedUsers?.map(user => {
-        const canSend =
-          !sentMembers?.some(sentHistory => sentHistory.receiverId === user.id) ||
-          receivedMembers?.some(receivedHistory => receivedHistory.senderId === user.id);
+      {searchedUserWithState?.map(
+        ({ user, canSend, count, modifiedLastReceived, receivedUserCount }) => {
+          return (
+            <S.UserWrappr key={user.id}>
+              <S.UserImageWrapper>
+                <S.UserImage src={`${BASE_URL}${user.imageUrl}`} />
+              </S.UserImageWrapper>
+              <S.UserName>{user.name}</S.UserName>
+              {modifiedLastReceived && (
+                <S.ModifiedAt>{`${modifiedLastReceived}에 콕!`}</S.ModifiedAt>
+              )}
 
-        const count = sentMembers?.find(sentHistory => sentHistory.receiverId === user.id)?.count;
-        const lastReceived =
-          sentMembers?.find(sentHistory => sentHistory.receiverId === user.id)?.modifiedAt ||
-          receivedMembers?.find(receiveHistory => receiveHistory.senderId === user.id)?.modifiedAt;
-        const modifiedLastReceived = lastReceived?.split(' ')[0];
-        const receivedUserCount = receivedMembers?.find(
-          receiveHistory => receiveHistory.senderId === user.id
-        )?.count;
-
-        return (
-          <S.UserWrappr key={user.id}>
-            <S.UserImageWrapper>
-              <S.UserImage src={`${BASE_URL}${user.imageUrl}`} />
-            </S.UserImageWrapper>
-            <S.UserName>{user.name}</S.UserName>
-            {modifiedLastReceived && <S.ModifiedAt>{`${modifiedLastReceived}에 콕!`}</S.ModifiedAt>}
-
-            <S.CountWrapper>
-              <S.CountLabel>연속</S.CountLabel>{' '}
-              <S.CountNum>{`${count || receivedUserCount || 0}회`}</S.CountNum>
-            </S.CountWrapper>
-            <S.SendButtonWrapper>
-              <S.SendButton
-                canSend={canSend}
-                onClick={() => {
-                  if (canSend) {
-                    postHeart(user.id);
-                  }
-                }}
-              >
-                콕
-              </S.SendButton>
-            </S.SendButtonWrapper>
-          </S.UserWrappr>
-        );
-      })}
+              <S.CountWrapper>
+                <S.CountLabel>연속</S.CountLabel>{' '}
+                <S.CountNum>{`${count || receivedUserCount || 0}회`}</S.CountNum>
+              </S.CountWrapper>
+              <S.SendButtonWrapper>
+                <S.SendButton
+                  canSend={canSend}
+                  onClick={() => {
+                    if (canSend) {
+                      postHeart(user.id);
+                    }
+                  }}
+                >
+                  콕
+                </S.SendButton>
+              </S.SendButtonWrapper>
+            </S.UserWrappr>
+          );
+        }
+      )}
     </S.MembersContainer>
   );
 };

--- a/frontend/src/hooks/Hearts/useHeartsMembers.tsx
+++ b/frontend/src/hooks/Hearts/useHeartsMembers.tsx
@@ -8,11 +8,35 @@ const useHeartsMembers = (searchKeyword: string) => {
   const { data: heartHistory } = useGetHearts(); //
   const { mutate: postHeart } = usePostHeartMutation();
 
-  const matchedUsers = useFilterMatchedUser(searchKeyword, members);
+  const searchedUsers = useFilterMatchedUser(searchKeyword, members);
   const sentMembers = heartHistory?.sent!;
   const receivedMembers = heartHistory?.received!;
 
-  return { matchedUsers, sentMembers, receivedMembers, postHeart };
+  const searchedUserWithState = searchedUsers?.map(user => {
+    const canSend =
+      !sentMembers?.some(sentHistory => sentHistory.receiverId === user.id) ||
+      receivedMembers?.some(receivedHistory => receivedHistory.senderId === user.id);
+
+    const count = sentMembers?.find(sentHistory => sentHistory.receiverId === user.id)?.count;
+    const lastReceived =
+      sentMembers?.find(sentHistory => sentHistory.receiverId === user.id)?.modifiedAt ||
+      receivedMembers?.find(receiveHistory => receiveHistory.senderId === user.id)?.modifiedAt;
+    const modifiedLastReceived = lastReceived?.split(' ')[0];
+    const receivedUserCount = receivedMembers?.find(
+      receiveHistory => receiveHistory.senderId === user.id
+    )?.count;
+    return {
+      user: user,
+      canSend: canSend,
+      count: count,
+      modifiedLastReceived: modifiedLastReceived,
+      receivedUserCount: receivedUserCount,
+    };
+  });
+
+  searchedUserWithState.sort((a, b) => b?.count - a?.count);
+
+  return { searchedUserWithState, postHeart };
 };
 
 export default useHeartsMembers;


### PR DESCRIPTION
## 상세 내용
- count 기준으로 많이 주고받은 사람이 위로 올라오도록 수정한다.