### PR TITLE
fix: create-reservation 페이지 접근 시 에러가 발생하던 오류를 수정한다.

### DIFF
--- a/frontend/src/hooks/@queries/coupon.ts
+++ b/frontend/src/hooks/@queries/coupon.ts
@@ -30,6 +30,7 @@ export const useGetCouponDetail = (
         onError();
       },
       retry: false,
+      useErrorBoundary: false,
     }
   );
 


### PR DESCRIPTION
## 상세 내용
- 값이 없을 때 api call을 해서 path가 null이었던 문제가 있었다.
- useErrorBoundary를 false로 해서 에러가 전파되는 것을 방지했다.

