### PR TITLE
refactor: Component 폴더에 있는 컴포넌트의 type을 컨벤션에 맞게 수정한다.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,6 @@
     "react-dom": "^18.2.0",
     "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0",
-    "react-transition-group": "^4.4.5",
     "recoil": "^0.7.4"
   },
   "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thankoo",
-  "version": "1.14.5",
+  "version": "1.2.4",
   "main": "src/index.tsx",
   "license": "MIT",
   "scripts": {
@@ -10,6 +10,25 @@
     "dev-build": "webpack --progress --config webpack/webpack.dev.js",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
+  },
+  "dependencies": {
+    "@emotion/babel-plugin": "^11.9.2",
+    "@emotion/babel-preset-css-prop": "^11.2.0",
+    "@emotion/react": "^11.9.3",
+    "@emotion/styled": "^11.9.3",
+    "@material-ui/core": "^4.12.4",
+    "@material-ui/lab": "^4.0.0-alpha.61",
+    "@mui/icons-material": "^5.8.4",
+    "@mui/material": "^5.8.7",
+    "axios": "^0.27.2",
+    "emotion-reset": "^3.0.1",
+    "hangul-js": "^0.2.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-query": "^3.39.1",
+    "react-router-dom": "^6.3.0",
+    "react-transition-group": "^4.4.5",
+    "recoil": "^0.7.4"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",
@@ -34,12 +53,9 @@
     "@yarnpkg/pnpify": "^4.0.0-rc.11",
     "@yarnpkg/sdks": "^3.0.0-rc.11",
     "babel-loader": "^8.2.5",
-    "css-loader": "^6.7.1",
     "dotenv": "^16.0.1",
-    "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",
     "msw": "^0.43.0",
-    "style-loader": "^3.3.1",
     "thankoo-utils-type": "^0.1.1",
     "ts-loader": "^9.3.1",
     "typescript": "^4.7.4",
@@ -47,25 +63,6 @@
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.9.3",
     "webpack-merge": "^5.8.0"
-  },
-  "dependencies": {
-    "@emotion/babel-plugin": "^11.9.2",
-    "@emotion/babel-preset-css-prop": "^11.2.0",
-    "@emotion/react": "^11.9.3",
-    "@emotion/styled": "^11.9.3",
-    "@material-ui/core": "^4.12.4",
-    "@material-ui/lab": "^4.0.0-alpha.61",
-    "@mui/icons-material": "^5.8.4",
-    "@mui/material": "^5.8.7",
-    "axios": "^0.27.2",
-    "emotion-reset": "^3.0.1",
-    "hangul-js": "^0.2.6",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-query": "^3.39.1",
-    "react-router-dom": "^6.3.0",
-    "react-transition-group": "^4.4.5",
-    "recoil": "^0.7.4"
   },
   "packageManager": "yarn@3.2.1",
   "msw": {

--- a/frontend/src/components/@shared/ChoiceSlider.tsx
+++ b/frontend/src/components/@shared/ChoiceSlider.tsx
@@ -7,25 +7,13 @@ const ChoiceSlider = ({ children }) => {
 
 export default ChoiceSlider;
 
-type ContentProps = {
-  show: boolean;
-  totalLength: number;
-};
-type OptionsProps = {
-  show: boolean;
-};
-type OptionItemProps = {
-  isAccept: boolean;
-  totalIndex: number;
-  index: number;
-  show: boolean;
-};
 type ToggleContextState = {
   toggle: boolean;
   setToggle: Dispatch<SetStateAction<boolean>>;
   length: number;
   setLength: Dispatch<SetStateAction<number>>;
 };
+
 const ToggleContext = createContext<ToggleContextState>({
   toggle: false,
   setToggle: () => {},
@@ -97,13 +85,27 @@ ChoiceSlider.OptionItem = ({ children, onClick, index, isAccept, ...props }) => 
   );
 };
 
+type ContentStyleProps = {
+  show: boolean;
+  totalLength: number;
+};
+type OptionsStyleProps = {
+  show: boolean;
+};
+type OptionItemStyleProps = {
+  isAccept: boolean;
+  totalIndex: number;
+  index: number;
+  show: boolean;
+};
+
 const S = {
   Container: styled.div``,
   Inner: styled.div`
     display: flex;
     position: relative;
   `,
-  Content: styled.div<ContentProps>`
+  Content: styled.div<ContentStyleProps>`
     width: ${({ show, totalLength }) => (show ? `${100 - totalLength * 11}%` : '100%')};
     min-width: 55%;
     transition: all ease-in-out 0.1s;
@@ -112,7 +114,7 @@ const S = {
     border-radius: 11px;
     box-shadow: rgba(0, 0, 0, 0.25) 0px 14px 28px, rgba(0, 0, 0, 0.22) 0px 10px 10px;
   `,
-  Options: styled.div<OptionsProps>`
+  Options: styled.div<OptionsStyleProps>`
     display: flex;
     position: absolute;
     right: 0;
@@ -121,7 +123,7 @@ const S = {
     border-radius: 0 3px 3px 0;
     overflow: hidden;
   `,
-  OptionItem: styled.button<OptionItemProps>`
+  OptionItem: styled.button<OptionItemStyleProps>`
     position: absolute;
     background-color: ${({ theme, isAccept }) => (isAccept ? `${theme.primary}` : '#8e8e8e')};
     color: white;

--- a/frontend/src/components/@shared/ConditionalViewer.tsx
+++ b/frontend/src/components/@shared/ConditionalViewer.tsx
@@ -1,5 +1,13 @@
-const ConditionalViewer = ({ children, condition, replacement }) => {
-  return <>{condition ? children : replacement}</>;
+import { PropsWithChildren } from 'react';
+
+type ConditionalViewerProps = { showReplacement: boolean; replacement: React.ReactNode };
+
+const ConditionalViewer = ({
+  children,
+  showReplacement: condition,
+  replacement,
+}: PropsWithChildren<ConditionalViewerProps>) => {
+  return <>{condition ? replacement : children}</>;
 };
 
 export default ConditionalViewer;

--- a/frontend/src/components/@shared/CouponLayout.tsx
+++ b/frontend/src/components/@shared/CouponLayout.tsx
@@ -1,7 +1,20 @@
 import styled from '@emotion/styled';
 import { COUPON_IMAGE, RAND_COLORS } from '../../constants/coupon';
+import { CouponType } from '../../types/coupon';
 
-const CouponLayout = ({ id = 0, name = '', title = '', couponType = 'coffee' }) => {
+type CouponLayoutProps = {
+  id: number;
+  name: string;
+  title: string;
+  couponType: CouponType;
+};
+
+const CouponLayout = ({
+  id = 0,
+  name = '',
+  title = '',
+  couponType = 'coffee',
+}: CouponLayoutProps) => {
   return (
     <S.Layout>
       <S.Content
@@ -20,7 +33,7 @@ const CouponLayout = ({ id = 0, name = '', title = '', couponType = 'coffee' }) 
 
 export default CouponLayout;
 
-type ContentProp = {
+type ContentStyleProp = {
   backgroundColor: string;
   color: string;
 };
@@ -35,7 +48,7 @@ const S = {
     height: 14.5rem;
     box-shadow: rgba(0, 0, 0, 0.15) 0px 3px 3px 0px;
   `,
-  Content: styled.div<ContentProp>`
+  Content: styled.div<ContentStyleProp>`
     display: flex;
     align-items: center;
     flex-direction: column;

--- a/frontend/src/components/@shared/Dimmer.tsx
+++ b/frontend/src/components/@shared/Dimmer.tsx
@@ -1,16 +1,21 @@
 import styled from '@emotion/styled';
 
-const Dimmer = ({ show, onClick }) => {
+type DimmerProps = {
+  show: boolean;
+  onClick: () => void;
+};
+
+const Dimmer = ({ show, onClick }: DimmerProps) => {
   return <Container onClick={onClick} show={show} />;
 };
 
 export default Dimmer;
 
-type DimmerProps = {
+type DimmerStyleProps = {
   show: boolean;
 };
 
-const Container = styled.div<DimmerProps>`
+const Container = styled.div<DimmerStyleProps>`
   display: ${({ show }) => (show ? 'block' : 'none')};
   position: fixed;
   width: 100%;

--- a/frontend/src/components/@shared/Input.tsx
+++ b/frontend/src/components/@shared/Input.tsx
@@ -1,7 +1,13 @@
 import styled from '@emotion/styled';
 import CloseIcon from '@mui/icons-material/Close';
 
-const Input = ({ setValue, maxLength, ...rest }) => {
+type InputProps = {
+  setValue: React.Dispatch<React.SetStateAction<any>>;
+  maxLength: number;
+  [x: string]: any;
+};
+
+const Input = ({ setValue, maxLength, ...rest }: InputProps) => {
   const isValidInput = value => {
     return value.length <= maxLength;
   };

--- a/frontend/src/components/@shared/LongButton.tsx
+++ b/frontend/src/components/@shared/LongButton.tsx
@@ -2,9 +2,9 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import Button, { ButtonProps, ButtonStyleOptions } from './Button/Button';
 
-interface LongButtonProps extends ButtonProps {}
+interface LongButtonStyleProps extends ButtonProps {}
 
-const LongButton = styled(Button)<LongButtonProps>`
+const LongButton = styled(Button)<LongButtonStyleProps>`
   ${({ size = 'medium' }) => css`
     display: flex;
     justify-content: space-between;

--- a/frontend/src/components/@shared/Modal.tsx
+++ b/frontend/src/components/@shared/Modal.tsx
@@ -11,7 +11,7 @@ const Modal = () => {
   const { pathname } = useLocation();
   const currentPathname = useRef<string>(pathname);
   const modalContent = useRecoilValue(modalContentAtom);
-  const { close, show } = useModal();
+  const { closeModal, visible } = useModal();
   const ref = useRef<any>();
 
   useEffect(() => {
@@ -30,10 +30,10 @@ const Modal = () => {
         tabIndex={0}
         ref={ref}
         onKeyDown={e => {
-          if (e.nativeEvent.key === 'Escape') close();
+          if (e.nativeEvent.key === 'Escape') closeModal();
         }}
       >
-        <Dimmer show={!!show} onClick={close} />
+        <Dimmer show={!!visible} onClick={closeModal} />
         {modalContent}
       </section>
     </Portal>

--- a/frontend/src/components/@shared/Modal.tsx
+++ b/frontend/src/components/@shared/Modal.tsx
@@ -33,7 +33,7 @@ const Modal = () => {
           if (e.nativeEvent.key === 'Escape') close();
         }}
       >
-        <Dimmer show={show} onClick={close} />
+        <Dimmer show={!!show} onClick={close} />
         {modalContent}
       </section>
     </Portal>

--- a/frontend/src/components/@shared/Modal/BottomSheet.tsx
+++ b/frontend/src/components/@shared/Modal/BottomSheet.tsx
@@ -20,12 +20,12 @@ export default forwardRef(
   }
 );
 
-type BottomSheetLayoutProps = {
+type BottomSheetLayoutStyleProps = {
   size?: BottomSheetModalSize;
 };
 
 const S = {
-  Layout: styled.div<BottomSheetLayoutProps>`
+  Layout: styled.div<BottomSheetLayoutStyleProps>`
     position: fixed;
     bottom: 0;
     left: 50%;

--- a/frontend/src/components/@shared/Modal/BottomSheet.tsx
+++ b/frontend/src/components/@shared/Modal/BottomSheet.tsx
@@ -5,13 +5,13 @@ import { onMountFromBottomModal, unMountToBottomModal } from '../../../styles/An
 
 type BottomSheetModalSize = 'large' | 'medium' | 'small';
 
-interface IBottomSheetLayout {
+type BottomSheetProps = {
   children: ReactNode;
   size?: BottomSheetModalSize;
-}
+};
 
 export default forwardRef(
-  ({ children, size }: IBottomSheetLayout, ref: LegacyRef<HTMLDivElement>) => {
+  ({ children, size }: BottomSheetProps, ref: LegacyRef<HTMLDivElement>) => {
     return (
       <S.Layout ref={ref} size={size}>
         <S.Inner>{children}</S.Inner>

--- a/frontend/src/components/@shared/Modal/ModalWrapper.tsx
+++ b/frontend/src/components/@shared/Modal/ModalWrapper.tsx
@@ -9,13 +9,13 @@ type ModalWrapperProps = {
 };
 
 const ModalWrapper = ({ children, modal, isDisabled = false }: ModalWrapperProps) => {
-  const { visible, show, setModalContent } = useModal();
+  const { showModal, setModalContent } = useModal();
 
   return (
     <Container
       onClick={() => {
         if (!isDisabled) {
-          show();
+          showModal();
           setModalContent(modal);
         }
       }}

--- a/frontend/src/components/@shared/Modal/ModalWrapper.tsx
+++ b/frontend/src/components/@shared/Modal/ModalWrapper.tsx
@@ -2,13 +2,13 @@ import styled from '@emotion/styled';
 import { ReactNode } from 'react';
 import useModal from '../../../hooks/useModal';
 
-type ModalWrapperType = {
+type ModalWrapperProps = {
   children: JSX.Element;
   modal: ReactNode;
   isDisabled?: boolean;
 };
 
-const ModalWrapper = ({ children, modal, isDisabled = false }: ModalWrapperType) => {
+const ModalWrapper = ({ children, modal, isDisabled = false }: ModalWrapperProps) => {
   const { visible, show, setModalContent } = useModal();
 
   return (

--- a/frontend/src/components/@shared/ProfileIcon.tsx
+++ b/frontend/src/components/@shared/ProfileIcon.tsx
@@ -4,15 +4,13 @@ import PersonIcon from '@mui/icons-material/Person';
 import { FlexCenter } from '../../styles/mixIn';
 import { BASE_URL } from './../../constants/api';
 
-const ProfileIcon = ({
-  src,
-  size,
-  isSelected,
-}: {
+type ProfileIconProps = {
   src: string;
   size: any;
   isSelected?: boolean;
-}) => {
+};
+
+const ProfileIcon = ({ src, size, isSelected }: ProfileIconProps) => {
   const ImageUrl = `${BASE_URL}${src}`;
 
   if (src.includes('corgi'))
@@ -70,20 +68,20 @@ const ProfileIcon = ({
   );
 };
 
-type IconProp = {
+type IconStyleProp = {
   size: string;
 };
 
-type BackgroundProp = {
+type BackgroundStyleProp = {
   color: string;
   size: string;
   isSelected?: boolean;
 };
 
-const StyledProfileIcon = styled.img<IconProp>`
+const StyledProfileIcon = styled.img<IconStyleProp>`
   width: ${({ size }) => size};
 `;
-const StyledIconBackGround = styled.div<BackgroundProp>`
+const StyledIconBackGround = styled.div<BackgroundStyleProp>`
   ${FlexCenter}
   width: ${({ size }) => Number(size.split(/[^0-9]/g)[0]) * 1.3 + 'px'};
   height: ${({ size }) => Number(size.split(/[^0-9]/g)[0]) * 1.3 + 'px'};
@@ -95,7 +93,7 @@ const StyledIconBackGround = styled.div<BackgroundProp>`
   box-shadow: ${({ isSelected }) => (isSelected ? '0 0 0 7px inset tomato' : '')};
 `;
 
-const DefaultUserIcon = styled(PersonIcon)<IconProp>`
+const DefaultUserIcon = styled(PersonIcon)<IconStyleProp>`
   font-size: ${({ size }) => (size ? size : '1.5em')};
   fill: gray;
 `;

--- a/frontend/src/components/@shared/Spinner/SimpleSpinner.tsx
+++ b/frontend/src/components/@shared/Spinner/SimpleSpinner.tsx
@@ -1,10 +1,10 @@
 import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
-interface SpinnerProps {
+type SpinnerProps = {
   width?: string;
   height?: string;
-}
+};
 
 const load8 = keyframes`
     0% {

--- a/frontend/src/components/@shared/Spinner/SimpleSpinner.tsx
+++ b/frontend/src/components/@shared/Spinner/SimpleSpinner.tsx
@@ -1,7 +1,7 @@
 import { css, keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 
-type SpinnerProps = {
+type SpinnerStyleProps = {
   width?: string;
   height?: string;
 };
@@ -15,7 +15,7 @@ const load8 = keyframes`
     }
 `;
 
-const SimpleSpinner = styled.div<SpinnerProps>`
+const SimpleSpinner = styled.div<SpinnerStyleProps>`
   ${({ width = '1.2rem', height = '1.2rem' }) => css`
     width: ${width};
     height: ${height};

--- a/frontend/src/components/@shared/TabsNav.tsx
+++ b/frontend/src/components/@shared/TabsNav.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 
-interface TabsNavProps {
+type TabsNavProps = {
   children?: JSX.Element | string;
   onChangeTab: (string) => void;
   currentTab: string;
   tabList: {};
   selectableTabs: any[];
   className?: string;
-}
+};
 
 const TabsNav = ({
   children,

--- a/frontend/src/components/@shared/TabsNav.tsx
+++ b/frontend/src/components/@shared/TabsNav.tsx
@@ -37,7 +37,7 @@ const TabsNav = ({
   );
 };
 
-type ButtonProp = { isActive: boolean };
+type ButtonStyleProp = { isActive: boolean };
 
 const S = {
   Container: styled.div`
@@ -48,7 +48,7 @@ const S = {
     display: flex;
     gap: 10px;
   `,
-  Button: styled.button<ButtonProp>`
+  Button: styled.button<ButtonStyleProp>`
     border: none;
     background-color: transparent;
     padding: 0;

--- a/frontend/src/components/@shared/Time.tsx
+++ b/frontend/src/components/@shared/Time.tsx
@@ -1,9 +1,15 @@
 import styled from '@emotion/styled';
-import { useMemo } from 'react';
+import { SetStateAction, useMemo } from 'react';
 
 type TimeTable = {
   time: string;
   isPassed: boolean;
+};
+
+type TimeProps = {
+  selectedTime: string;
+  setSelectedTime: React.Dispatch<SetStateAction<string>>;
+  selectedDate: string;
 };
 
 const getCurrentTimeFormatYYMMDDHM = () => {
@@ -18,7 +24,7 @@ const getCurrentTimeFormatYYMMDDHM = () => {
   return `${nowYear}/${nowMonth}/${nowDate} ${nowHour}:${nowMin}:${nowSec}`;
 };
 
-const timeTableGenerator = (startHour, endHour, selectedDate) => {
+const timeTableGenerator = (startHour: number, endHour: number, selectedDate: string) => {
   const timeTable: TimeTable[] = [];
 
   for (let i = startHour; i < endHour + 1; i += 1) {
@@ -41,7 +47,7 @@ const timeTableGenerator = (startHour, endHour, selectedDate) => {
   return timeTable;
 };
 
-const Time = ({ selectedTime, setSelectedTime, selectedDate }) => {
+const Time = ({ selectedTime, setSelectedTime, selectedDate }: TimeProps) => {
   const dayTimeTable = useMemo(() => timeTableGenerator(10, 12, selectedDate), [selectedDate]);
   const nightTimeTable = useMemo(() => timeTableGenerator(12, 20, selectedDate), [selectedDate]);
 
@@ -93,7 +99,7 @@ const Time = ({ selectedTime, setSelectedTime, selectedDate }) => {
 
 export default Time;
 
-type TimeProps = {
+type TimeStyleProps = {
   isPassed: boolean;
   isSelected: boolean;
 };
@@ -119,7 +125,7 @@ const S = {
     color: white;
     font-size: 18px;
   `,
-  Time: styled.button<TimeProps>`
+  Time: styled.button<TimeStyleProps>`
     border: none;
     display: flex;
     align-items: center;

--- a/frontend/src/components/@shared/toast/ToastItem.tsx
+++ b/frontend/src/components/@shared/toast/ToastItem.tsx
@@ -5,7 +5,12 @@ import useToast from './../../../hooks/useToast';
 import { onMountToast, unMountToast } from './../../../styles/Animation';
 import CloseButton from './../CloseButton';
 
-const ToastItem = ({ toastKey, comment }) => {
+type ToastItemProps = {
+  toastKey: number;
+  comment: string;
+};
+
+const ToastItem = ({ toastKey, comment }: ToastItemProps) => {
   const { toastRef, closeToastItem, duration } = useToast();
 
   useEffect(() => {
@@ -41,6 +46,10 @@ const ToastItem = ({ toastKey, comment }) => {
   );
 };
 
+type ProgressBarStyleProps = {
+  duration: number;
+};
+
 const S = {
   ToastItem: styled.div`
     position: relative;
@@ -62,7 +71,6 @@ const S = {
       animation: ${unMountToast} 2000ms;
     }
   `,
-
   Comment: styled.p`
     display: inline;
   `,
@@ -74,7 +82,7 @@ const S = {
     top: 7px;
     right: -2px;
   `,
-  ProgressBar: styled.div<ProgressBarProps>`
+  ProgressBar: styled.div<ProgressBarStyleProps>`
     width: 100%;
     height: 5px;
     position: absolute;
@@ -102,10 +110,6 @@ const S = {
       }
     }
   `,
-};
-
-type ProgressBarProps = {
-  duration: number;
 };
 
 export default ToastItem;

--- a/frontend/src/components/PageButton/CouponListPageButton.tsx
+++ b/frontend/src/components/PageButton/CouponListPageButton.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+import HomeIcon from '@mui/icons-material/Home';
 import { Link, useLocation } from 'react-router-dom';
 import { ROUTE_PATH } from '../../constants/routes';
-import HomeIcon from '@mui/icons-material/Home';
 
 const CouponsPageButton = () => {
   const location = useLocation();
@@ -21,7 +21,7 @@ const CouponsPageButton = () => {
 
 export default CouponsPageButton;
 
-type ButtonProps = {
+type ButtonStyleProps = {
   active: boolean;
 };
 
@@ -32,7 +32,7 @@ const S = {
       font-size: 12px;
     }
   `,
-  ButtonWrapper: styled.div<ButtonProps>`
+  ButtonWrapper: styled.div<ButtonStyleProps>`
     opacity: 0.5;
     ${({ active }) =>
       active &&

--- a/frontend/src/components/PageButton/HeartPageButton.tsx
+++ b/frontend/src/components/PageButton/HeartPageButton.tsx
@@ -20,7 +20,7 @@ const HeartPageButton = () => {
 };
 export default HeartPageButton;
 
-type ButtonProps = {
+type ButtonStyleProps = {
   active: boolean;
 };
 
@@ -32,7 +32,7 @@ const S = {
       font-size: 12px;
     }
   `,
-  ButtonWrapper: styled.div<ButtonProps>`
+  ButtonWrapper: styled.div<ButtonStyleProps>`
     position: relative;
     opacity: 0.5;
     ${({ active }) =>

--- a/frontend/src/components/PageButton/MeetingPageButton.tsx
+++ b/frontend/src/components/PageButton/MeetingPageButton.tsx
@@ -30,7 +30,7 @@ const MeetingPageButton = () => {
   );
 };
 
-type ButtonProps = {
+type ButtonStyleProps = {
   active: boolean;
 };
 
@@ -41,7 +41,7 @@ const S = {
       font-size: 12px;
     }
   `,
-  ButtonWrapper: styled.div<ButtonProps>`
+  ButtonWrapper: styled.div<ButtonStyleProps>`
     position: relative;
 
     opacity: 0.5;

--- a/frontend/src/components/PageButton/ReservationPageButton.tsx
+++ b/frontend/src/components/PageButton/ReservationPageButton.tsx
@@ -24,7 +24,7 @@ const ReservationPageButton = () => {
 
 export default ReservationPageButton;
 
-type ButtonProps = {
+type ButtonStyleProps = {
   active: boolean;
 };
 
@@ -36,7 +36,7 @@ const S = {
       font-size: 12px;
     }
   `,
-  ButtonWrapper: styled.div<ButtonProps>`
+  ButtonWrapper: styled.div<ButtonStyleProps>`
     position: relative;
     opacity: 0.5;
     ${({ active }) =>

--- a/frontend/src/components/PageButton/SendCouponPageButton.tsx
+++ b/frontend/src/components/PageButton/SendCouponPageButton.tsx
@@ -21,7 +21,7 @@ const SendCouponPageButton = () => {
 };
 export default SendCouponPageButton;
 
-type ButtonProps = {
+type ButtonStyleProps = {
   active: boolean;
 };
 
@@ -33,7 +33,7 @@ const S = {
       font-size: 12px;
     }
   `,
-  ButtonWrapper: styled.div<ButtonProps>`
+  ButtonWrapper: styled.div<ButtonStyleProps>`
     position: relative;
     opacity: 0.5;
     ${({ active }) =>

--- a/frontend/src/hooks/@queries/profile.ts
+++ b/frontend/src/hooks/@queries/profile.ts
@@ -1,12 +1,12 @@
 import { useMutation, useQuery } from 'react-query';
-import { API_PATH } from '../../constants/api';
 import { client } from '../../apis/axios';
+import { API_PATH } from '../../constants/api';
 import { UserProfile } from '../../types/user';
 
-export interface exchangeCount {
+export type exchangeCount = {
   sentCount: number;
   receivedCount: number;
-}
+};
 
 export const PROFILE_QUERY_KEY = {
   profile: 'profile',

--- a/frontend/src/hooks/useModal.ts
+++ b/frontend/src/hooks/useModal.ts
@@ -15,11 +15,11 @@ const useModal = () => {
     }
   }, []);
 
-  const show = () => {
+  const showModal = () => {
     setVisible(true);
   };
 
-  const close = () => {
+  const closeModal = () => {
     const target = document.getElementsByClassName('onMount modalContainer')[0];
     if (!target) {
       setVisible(false);
@@ -33,7 +33,7 @@ const useModal = () => {
     }, modalUnMountTime);
   };
 
-  return { show, close, visible, setModalContent, modalContentRef };
+  return { showModal, closeModal, visible, setModalContent, modalContentRef };
 };
 
 export default useModal;

--- a/frontend/src/hooks/useQRCoupon.tsx
+++ b/frontend/src/hooks/useQRCoupon.tsx
@@ -19,7 +19,7 @@ export type QRCouponResponse = {
 
 const useQRCoupon = () => {
   const { search } = useLocation();
-  const { show, setModalContent } = useModal();
+  const { showModal, setModalContent } = useModal();
   const navigate = useNavigate();
 
   const query = localStorage.getItem('query') || search;
@@ -37,7 +37,7 @@ const useQRCoupon = () => {
     },
     {
       onSuccess: res => {
-        show();
+        showModal();
         setModalContent(<QRCouponRegisterModal QRCode={res} serialCode={code} />);
       },
       onError: error => {

--- a/frontend/src/mocks/dummyData.ts
+++ b/frontend/src/mocks/dummyData.ts
@@ -1,12 +1,12 @@
 import { Coupon } from '../types/coupon';
 
-interface User {
+type User = {
   id: number;
   name: string;
   imageUrl: string;
   email: string;
   accessToken?: number;
-}
+};
 
 export const users: User[] = [
   {

--- a/frontend/src/pages/CreateReservation/components/ConfirmReservationModal.tsx
+++ b/frontend/src/pages/CreateReservation/components/ConfirmReservationModal.tsx
@@ -4,7 +4,7 @@ import BottomSheetLayout from '../../../components/@shared/Modal/BottomSheet';
 import useModal from '../../../hooks/useModal';
 
 const ConfirmReservationModal = ({ submit, time, date, receiver }) => {
-  const { close, modalContentRef } = useModal();
+  const { closeModal, modalContentRef } = useModal();
 
   return (
     <BottomSheetLayout ref={modalContentRef}>
@@ -24,7 +24,7 @@ const ConfirmReservationModal = ({ submit, time, date, receiver }) => {
         </S.ConfirmContentWrapper>
       </S.SpaceBetween>
       <S.ButtonWrapper>
-        <Button onClick={close} color='secondaryLight'>
+        <Button onClick={closeModal} color='secondaryLight'>
           취소
         </Button>
         <Button onClick={submit}>예약</Button>

--- a/frontend/src/pages/CreateReservation/components/ConfirmReservationModal.tsx
+++ b/frontend/src/pages/CreateReservation/components/ConfirmReservationModal.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
-import useModal from '../../../hooks/useModal';
 import Button from '../../../components/@shared/Button/Button';
-import BottomSheetLayout from '../../../components/@shared/Modal/BottomSheetLayout';
+import BottomSheetLayout from '../../../components/@shared/Modal/BottomSheet';
+import useModal from '../../../hooks/useModal';
 
 const ConfirmReservationModal = ({ submit, time, date, receiver }) => {
   const { close, modalContentRef } = useModal();

--- a/frontend/src/pages/CreateReservation/hooks/useCreateReservation.ts
+++ b/frontend/src/pages/CreateReservation/hooks/useCreateReservation.ts
@@ -2,13 +2,13 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { ROUTE_PATH } from '../../../constants/routes';
-import { targetCouponAtom } from '../../../recoil/atom';
-import { getNowKrLocaleFullDateISOFormat } from '../../../utils/date';
 import { useGetCouponDetail } from '../../../hooks/@queries/coupon';
 import { usePostReservationMutation } from '../../../hooks/@queries/reservation';
 import useModal from '../../../hooks/useModal';
 import useOnSuccess from '../../../hooks/useOnSuccess';
 import useToast from '../../../hooks/useToast';
+import { targetCouponAtom } from '../../../recoil/atom';
+import { getNowKrLocaleFullDateISOFormat } from '../../../utils/date';
 
 const today = getNowKrLocaleFullDateISOFormat().split(' ')[0];
 
@@ -20,7 +20,7 @@ const useCreateReservation = () => {
   const [date, setDate] = useState(today);
   const [time, setTime] = useState('');
   const isFilled = date && time.length;
-  const { close } = useModal();
+  const { closeModal } = useModal();
 
   const { data: couponDetail } = useGetCouponDetail(couponId, {
     onError: () => {
@@ -44,7 +44,7 @@ const useCreateReservation = () => {
             time,
           },
         });
-        close();
+        closeModal();
       },
       onError: () => {
         insertToastItem('예약이 불가능한 날짜입니다.');

--- a/frontend/src/pages/EnterCouponContent/components/ConfirmCouponContentModal.tsx
+++ b/frontend/src/pages/EnterCouponContent/components/ConfirmCouponContentModal.tsx
@@ -1,15 +1,15 @@
 import styled from '@emotion/styled';
 import { useRecoilValue } from 'recoil';
-import { usePostCouponMutation } from '../../../hooks/@queries/coupon';
-import useModal from '../../../hooks/useModal';
-import { CouponType, couponTypes } from '../../../types/coupon';
-import { UserProfile } from '../../../types/user';
 import Button from '../../../components/@shared/Button/Button';
-import BottomSheetLayout from '../../../components/@shared/Modal/BottomSheetLayout';
+import BottomSheetLayout from '../../../components/@shared/Modal/BottomSheet';
 import { BASE_URL } from '../../../constants/api';
 import { ROUTE_PATH } from '../../../constants/routes';
+import { usePostCouponMutation } from '../../../hooks/@queries/coupon';
+import useModal from '../../../hooks/useModal';
 import useOnSuccess from '../../../hooks/useOnSuccess';
 import { checkedUsersAtom } from '../../../recoil/atom';
+import { CouponType, couponTypes } from '../../../types/coupon';
+import { UserProfile } from '../../../types/user';
 
 const ConfirmCouponContentModal = ({
   message,

--- a/frontend/src/pages/EnterCouponContent/components/ConfirmCouponContentModal.tsx
+++ b/frontend/src/pages/EnterCouponContent/components/ConfirmCouponContentModal.tsx
@@ -22,7 +22,7 @@ const ConfirmCouponContentModal = ({
   receivers: UserProfile[];
   couponType: CouponType;
 }) => {
-  const { close, modalContentRef } = useModal();
+  const { closeModal, modalContentRef } = useModal();
   const { successNavigate } = useOnSuccess();
   const checkedUsers = useRecoilValue<UserProfile[]>(checkedUsersAtom);
 
@@ -42,7 +42,7 @@ const ConfirmCouponContentModal = ({
             title,
           },
         });
-        close();
+        closeModal();
       },
     }
   );
@@ -74,7 +74,7 @@ const ConfirmCouponContentModal = ({
         <S.ConfirmContentText>{message}</S.ConfirmContentText>
       </S.ConfirmContentWrapper>
       <S.ButtonWrapper>
-        <Button color='secondaryLight' onClick={close}>
+        <Button color='secondaryLight' onClick={closeModal}>
           취소
         </Button>
         <Button

--- a/frontend/src/pages/EnterCouponContent/hooks/useEnterCouponContent.ts
+++ b/frontend/src/pages/EnterCouponContent/hooks/useEnterCouponContent.ts
@@ -1,13 +1,12 @@
 import { ChangeEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
+import { COUPON_MESSEGE_MAX_LENGTH, COUPON_TITLE_MAX_LENGTH } from '../../../constants/coupon';
 import { ROUTE_PATH } from '../../../constants/routes';
+import { useGetUserProfile } from '../../../hooks/@queries/profile';
 import { checkedUsersAtom } from '../../../recoil/atom';
 import { CouponTransmitableType } from '../../../types/coupon';
 import { UserProfile } from '../../../types/user';
-import { useGetUserProfile } from '../../../hooks/@queries/profile';
-import useModal from '../../../hooks/useModal';
-import { COUPON_MESSEGE_MAX_LENGTH, COUPON_TITLE_MAX_LENGTH } from '../../../constants/coupon';
 
 const useEnterCouponContent = () => {
   const navigate = useNavigate();
@@ -20,7 +19,6 @@ const useEnterCouponContent = () => {
   const { data: userProfile, isLoading } = useGetUserProfile();
 
   const isFilled = !!title.trim() && !!message.trim();
-  const { close } = useModal();
 
   const handleOnchangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
     const targetValue = e.target.value;

--- a/frontend/src/pages/Hearts/components/ListViewHeartSkeleton.tsx
+++ b/frontend/src/pages/Hearts/components/ListViewHeartSkeleton.tsx
@@ -3,9 +3,9 @@ import Button from '../../../components/@shared/Button/Button';
 import { FlexCenter } from '../../../styles/mixIn';
 import { UserProfile } from '../../../types/user';
 
-interface ListViewHeartSkeletonProps {
+type ListViewHeartSkeletonProps = {
   user: UserProfile;
-}
+};
 
 const ListViewHeartSkeleton = ({ user }: ListViewHeartSkeletonProps) => {
   return (

--- a/frontend/src/pages/Hearts/hooks/useHeartsMembers.tsx
+++ b/frontend/src/pages/Hearts/hooks/useHeartsMembers.tsx
@@ -1,18 +1,18 @@
 import { useMemo } from 'react';
 import { YYYYMMDD } from 'thankoo-utils-type';
 import { useGetHearts } from '../../../hooks/@queries/hearts';
+import { useGetMembers } from '../../../hooks/@queries/members';
 import { UserProfile } from '../../../types/user';
 import { sorted } from '../../../utils';
-import { useGetMembers } from '../../../hooks/@queries/members';
 
 import useFilterMatchedUser from '../../../hooks/useFilterMatchedUser';
 
-export interface Hearts {
+export type Hearts = {
   canSend: boolean;
   modifiedLastReceived: YYYYMMDD;
   sentCount: number;
   user: UserProfile;
-}
+};
 
 const useHeartsMembers = (searchKeyword: string) => {
   const { data: members } = useGetMembers();

--- a/frontend/src/pages/Main/components/QRCouponRegisterModal.tsx
+++ b/frontend/src/pages/Main/components/QRCouponRegisterModal.tsx
@@ -23,7 +23,7 @@ const QRCouponRegisterModal = ({
   QRCode: QRCouponResponse;
   serialCode: string;
 }) => {
-  const { modalContentRef, close } = useModal();
+  const { modalContentRef, closeModal } = useModal();
   const { insertToastItem } = useToast();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -37,7 +37,7 @@ const QRCouponRegisterModal = ({
       }),
     {
       onMutate: () => {
-        close();
+        closeModal();
       },
       onSuccess: () => {
         localStorage.removeItem('query');
@@ -75,7 +75,7 @@ const QRCouponRegisterModal = ({
           <Button
             color='secondaryLight'
             onClick={() => {
-              close();
+              closeModal();
               localStorage.removeItem('query');
               navigate(ROUTE_PATH.EXACT_MAIN, { replace: true });
             }}

--- a/frontend/src/pages/Main/hooks/useCouponDetail.ts
+++ b/frontend/src/pages/Main/hooks/useCouponDetail.ts
@@ -2,8 +2,6 @@ import { useQueryClient } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { ROUTE_PATH } from '../../../constants/routes';
-import { sentOrReceivedAtom, targetCouponAtom } from '../../../recoil/atom';
-import { CouponDetailButton, CouponDetailButtonProps } from '../../../types/coupon';
 import {
   COUPON_QUERY_KEY,
   useGetCouponDetail,
@@ -16,6 +14,8 @@ import {
 } from '../../../hooks/@queries/reservation';
 import useModal from '../../../hooks/useModal';
 import useToast from '../../../hooks/useToast';
+import { sentOrReceivedAtom, targetCouponAtom } from '../../../recoil/atom';
+import { CouponDetailButton, CouponDetailButtonProps } from '../../../types/coupon';
 
 export const 예약요청응답별코멘트 = {
   accept: '예약을 승인 했습니다.',
@@ -25,7 +25,7 @@ export const 예약요청응답별코멘트 = {
 export const useCouponDetail = (couponId: number) => {
   const queryClient = useQueryClient();
   const [_, setTargetCouponId] = useRecoilState(targetCouponAtom);
-  const { close } = useModal();
+  const { closeModal } = useModal();
   const { insertToastItem } = useToast();
 
   const { data: couponDetail, isError, isLoading } = useGetCouponDetail(couponId);
@@ -38,7 +38,7 @@ export const useCouponDetail = (couponId: number) => {
     onSuccess: () => {
       queryClient.invalidateQueries([COUPON_QUERY_KEY.coupon]);
       insertToastItem('예약을 취소했습니다.');
-      close();
+      closeModal();
     },
     onError: error => {
       insertToastItem(error.response?.data.message);
@@ -48,7 +48,7 @@ export const useCouponDetail = (couponId: number) => {
     onSuccess: () => {
       queryClient.invalidateQueries([COUPON_QUERY_KEY.coupon]);
       insertToastItem('✅ 쿠폰을 사용했습니다');
-      close();
+      closeModal();
     },
     onError: error => {
       insertToastItem(error.response?.data.message);
@@ -58,7 +58,7 @@ export const useCouponDetail = (couponId: number) => {
     onSuccess: status => {
       queryClient.invalidateQueries([COUPON_QUERY_KEY.coupon]);
       insertToastItem(예약요청응답별코멘트[status]);
-      close();
+      closeModal();
     },
     onError: error => {
       insertToastItem(error.response?.data.message);
@@ -69,7 +69,7 @@ export const useCouponDetail = (couponId: number) => {
     onSuccess: () => {
       queryClient.invalidateQueries([COUPON_QUERY_KEY.coupon]);
       insertToastItem('쿠폰 사용 완료했습니다.');
-      close();
+      closeModal();
     },
     onError: error => {
       insertToastItem(error.response?.data.message);
@@ -94,7 +94,7 @@ export const useCouponDetail = (couponId: number) => {
           color: 'secondaryLight',
           onClick: () => {
             setTargetCouponId(couponId);
-            close();
+            closeModal();
             navigate(ROUTE_PATH.CREATE_RESERVATION);
           },
         },
@@ -174,6 +174,6 @@ export const useCouponDetail = (couponId: number) => {
     isLoading,
     isError,
     buttonOptions,
-    close,
+    close: closeModal,
   };
 };

--- a/frontend/src/pages/Meetings/components/ListViewMeetings.tsx
+++ b/frontend/src/pages/Meetings/components/ListViewMeetings.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
-import { COUPON_IMAGE } from '../../../constants/coupon';
-import useMeetings from '../hooks/useMeetings';
-import HeaderText from '../../../layout/HeaderText';
 import ConditionalViewer from '../../../components/@shared/ConditionalViewer';
 import NoMeeting from '../../../components/@shared/noContent/NoMeeting';
+import { COUPON_IMAGE } from '../../../constants/coupon';
+import HeaderText from '../../../layout/HeaderText';
+import useMeetings from '../hooks/useMeetings';
 
 const ListViewMeetings = () => {
   const { meetings, meetingDateAnnouncement } = useMeetings();
@@ -12,7 +12,7 @@ const ListViewMeetings = () => {
     <>
       <S.HeaderText>{meetingDateAnnouncement}</S.HeaderText>
       <S.Body>
-        <ConditionalViewer condition={meetings?.length !== 0} replacement={<NoMeeting />}>
+        <ConditionalViewer showReplacement={meetings?.length === 0} replacement={<NoMeeting />}>
           {meetings?.map((meeting, idx) => (
             <S.Meeting isToday={meeting.isMeetingToday} key={idx}>
               {meeting.isMeetingToday && <S.TodayStrap>오늘</S.TodayStrap>}
@@ -45,7 +45,7 @@ const ListViewMeetings = () => {
 
 export default ListViewMeetings;
 
-type MeetingWrapperProps = {
+type MeetingWrapperStyleProps = {
   isToday: boolean;
 };
 
@@ -60,7 +60,7 @@ const S = {
     height: 100%;
     overflow: auto;
   `,
-  Meeting: styled.div<MeetingWrapperProps>`
+  Meeting: styled.div<MeetingWrapperStyleProps>`
     position: relative;
     width: 100%;
     color: white;

--- a/frontend/src/pages/Profile/components/SelectProfileImgModal.tsx
+++ b/frontend/src/pages/Profile/components/SelectProfileImgModal.tsx
@@ -9,7 +9,7 @@ import useModal from '../../../hooks/useModal';
 
 const SelectProfileImgModal = ({ editUserProfileImage }) => {
   const [selected, setSelected] = useState('');
-  const { visible, close, modalContentRef } = useModal();
+  const { visible, closeModal, modalContentRef } = useModal();
 
   return (
     <S.Container show={visible} ref={modalContentRef}>
@@ -28,13 +28,13 @@ const SelectProfileImgModal = ({ editUserProfileImage }) => {
           ))}
         </S.ProfileContainer>
         <S.ButtonWrapper>
-          <Button color='secondaryLight' onClick={close}>
+          <Button color='secondaryLight' onClick={closeModal}>
             취소
           </Button>
           <Button
             onClick={() => {
               editUserProfileImage(selected);
-              close();
+              closeModal();
             }}
           >
             변경하기

--- a/frontend/src/recoil/atom.ts
+++ b/frontend/src/recoil/atom.ts
@@ -42,10 +42,10 @@ export const toastVisibleAtom = atom({
   default: false,
 });
 
-interface toastItem {
+type toastItem = {
   key: number;
   comment: string;
-}
+};
 
 export const toastStackAtom = atom<toastItem[]>({
   //modify
@@ -54,10 +54,10 @@ export const toastStackAtom = atom<toastItem[]>({
 });
 
 // SuccessPage 내부 컨텐츠
-export interface SuccessContentType {
+export type SuccessContentType = {
   page: string;
   props: any;
-}
+};
 
 export const onSuccessContentAtom = atom<SuccessContentType>({
   key: 'onSuccessContentAtom',

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,11 +1,11 @@
 import { AxiosError } from 'axios';
 
-export interface ErrorType {
+export type ErrorType = {
   errorCode: number;
   message: string;
-}
+};
 
-export interface QueryHandlers {
+export type QueryHandlers = {
   onSuccess: () => void;
   onError: (error: AxiosError<ErrorType>) => void;
-}
+};

--- a/frontend/src/types/coupon.ts
+++ b/frontend/src/types/coupon.ts
@@ -12,7 +12,7 @@ export type CouponStatus =
   | 'not_used'
   | 'immediately_used';
 
-export interface Coupon {
+export type Coupon = {
   couponId: number;
   sender: UserProfile;
   receiver: UserProfile;
@@ -20,18 +20,18 @@ export interface Coupon {
   status: CouponStatus;
   createdDate: YYYYMMDD;
   modifiedDateTime: string;
-}
-export interface CouponDetail {
+};
+export type CouponDetail = {
   coupon: Coupon;
   meeting: Meeting | null;
   reservation: Reservation | null;
-}
+};
 
-export interface CouponContent {
+export type CouponContent = {
   couponType: CouponTransmitableType;
   title: string;
   message: string;
-}
+};
 
 export type CouponTransmitStatus = 'received' | 'sent';
 

--- a/frontend/src/types/meeting.ts
+++ b/frontend/src/types/meeting.ts
@@ -6,11 +6,11 @@ export type MeetingTime = {
   timeZone: string;
 };
 
-export interface Meeting {
+export type Meeting = {
   meetingId: number;
   couponType: CouponType;
   time: MeetingTime;
   members: UserProfile[];
   memberName: string;
   isMeetingToday: boolean;
-}
+};

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,6 +1,6 @@
-export interface UserProfile {
+export type UserProfile = {
   id: number;
   name: string;
   email: string;
   imageUrl: string;
-}
+};


### PR DESCRIPTION
## 상세 내용
### Package정리
- 불필요한 package를 삭제하였습니다.

### Type 정리
- src/component로 분리한 폴더에 있는 컴포넌트들에만 적용하였습니다.
- interface는 extends, 선언병합 등 메서드가 필요한 경우에만 사용하고 type을 사용하도록 변경했습니다.
- 진행하면서 잘못된 타입과 값을 주고받는 경우 수정하였습니다.
  - Dimmer에서 boolean으로 hide를 받아야 하는데 잘못 적용 돼 있어 수정하였습니다.
- 이모션 컴포넌트의 변수로 Props를 사용한 경우 ~styleProps로 접미사를 추가하였습니다.
해당 접미사가 없을경우 컴포넌트의 props와 겹칠 수 있습니다.
- 가능한 경우 컴포넌트의 Props에 [컴포넌트명]Props를 추가했습니다.

Close #631 #632

