### PR TITLE
fix: ChoiceSlider의 option을 2개 이상 사용할 때 UI가 깨지는 문제를 해결한다.

### DIFF
--- a/frontend/src/components/@shared/ChoiceSlider.tsx
+++ b/frontend/src/components/@shared/ChoiceSlider.tsx
@@ -109,7 +109,7 @@ const S = {
     width: ${({ show, totalLength }) => (show ? `${100 - totalLength * 11}%` : '100%')};
     min-width: 55%;
     transition: all ease-in-out 0.1s;
-    z-index: 3;
+    z-index: ${({ totalLength }) => totalLength + 1};
     overflow: hidden;
     border-radius: 11px;
     box-shadow: rgba(0, 0, 0, 0.25) 0px 14px 28px, rgba(0, 0, 0, 0.22) 0px 10px 10px;
@@ -129,7 +129,7 @@ const S = {
     color: white;
     font-weight: bold;
     word-break: keep-all;
-    padding: 10px;
+    padding: 3%;
     border: none;
     border-radius: 11px;
     width: ${({ index, show, totalIndex }) =>

--- a/frontend/src/components/@shared/ChoiceSlider.tsx
+++ b/frontend/src/components/@shared/ChoiceSlider.tsx
@@ -136,7 +136,7 @@ const S = {
       show ? `${100 - (totalIndex - index) * 11}%` : '100%'};
     transition: all ease-in-out 0.1s;
     height: 100%;
-    z-index: ${({ index }) => 2 - index};
+    z-index: ${({ totalIndex, index }) => totalIndex - index};
     display: flex;
     justify-content: flex-end;
     align-items: center;

--- a/frontend/src/components/@shared/ChoiceSlider.tsx
+++ b/frontend/src/components/@shared/ChoiceSlider.tsx
@@ -58,17 +58,22 @@ ChoiceSlider.Toggle = ({ children, ...props }: ToggleProps) => {
   );
 };
 
-ChoiceSlider.Options = ({ children, ...props }) => {
+const isMultipleChildren = (input): input is ReactElement[] => {
+  return Array.isArray(input);
+};
+type PropsWithReactElementChild = {
+  children: ReactElement | ReactElement[];
+};
+ChoiceSlider.Options = ({ children, ...props }: PropsWithReactElementChild) => {
   if (React.Children.count(children) > 3) {
     throw new Error('ChoiceSlider의 OptionsItem은 3개가 최대입니다.');
   }
 
-  const indexedChildren = React.Children.toArray(children).map((child, idx) => {
-    const reactElementChild = child as ReactElement;
-
+  const childList = isMultipleChildren(children) ? children : [children];
+  const indexedChildren = childList.map((child: ReactElement, idx) => {
     return {
-      ...reactElementChild,
-      props: { ...reactElementChild.props, index: idx + 1 },
+      ...child,
+      props: { ...child.props, index: idx + 1 },
     };
   });
 
@@ -86,16 +91,10 @@ ChoiceSlider.Options = ({ children, ...props }) => {
 };
 
 type OptionItemProps = {
-  backgroundColor: string;
   index?: number;
 } & PropsWithChildren;
 
-ChoiceSlider.OptionItem = ({
-  children,
-  backgroundColor = '#8e8e8e',
-  index,
-  ...props
-}: OptionItemProps) => {
+ChoiceSlider.OptionItem = ({ children, index, ...props }: OptionItemProps) => {
   const { setToggle, toggle, length } = useContext(ToggleContext);
 
   return (
@@ -106,7 +105,6 @@ ChoiceSlider.OptionItem = ({
       onClick={() => {
         setToggle(prev => !prev);
       }}
-      backgroundColor={backgroundColor}
       {...props}
     >
       {children}
@@ -125,7 +123,6 @@ type OptionItemStyleProps = {
   totalIndex: number;
   index: number;
   show: boolean;
-  backgroundColor: string;
 };
 
 const S = {
@@ -153,13 +150,8 @@ const S = {
   `,
   OptionItem: styled.button<OptionItemStyleProps>`
     position: absolute;
-    color: white;
-    font-weight: bold;
-    word-break: keep-all;
-    padding: 3%;
+    padding: 0;
     border: none;
-    background-color: ${({ backgroundColor }) => backgroundColor};
-    border-radius: 11px;
     width: ${({ index, show, totalIndex }) =>
       show ? `${100 - (totalIndex - index) * 11}%` : '100%'};
     transition: all ease-in-out 0.1s;
@@ -168,6 +160,8 @@ const S = {
     display: flex;
     justify-content: flex-end;
     align-items: center;
+    border-radius: 11px;
+    overflow: hidden;
     box-shadow: rgba(0, 0, 0, 0.25) 0px 14px 28px, rgba(0, 0, 0, 0.22) 0px 10px 10px;
   `,
 };

--- a/frontend/src/pages/Reservations/components/ListReservationItem.tsx
+++ b/frontend/src/pages/Reservations/components/ListReservationItem.tsx
@@ -23,44 +23,31 @@ const ListReservationItem = ({
 
   return (
     <Slider>
-      <Slider.Inner>
-        <Slider.Content>
-          <ListViewReservationDetail
-            couponType={couponType}
-            meetingTime={time.meetingTime}
-            memberName={memberName}
-            reservationId={reservationId}
-          />
-        </Slider.Content>
+      <Slider.Toggle>
+        <ListViewReservationDetail
+          couponType={couponType}
+          meetingTime={time.meetingTime}
+          memberName={memberName}
+          reservationId={reservationId}
+        />
+      </Slider.Toggle>
+      {transmitStatus === 'received' ? (
         <Slider.Options>
-          {transmitStatus === 'received' ? (
-            <>
-              <Slider.OptionItem
-                index={1}
-                isAccept={false}
-                onClick={handleClickOption[transmitStatus][0]}
-              >
-                거절
-              </Slider.OptionItem>
-              <Slider.OptionItem
-                index={2}
-                isAccept={true}
-                onClick={handleClickOption[transmitStatus][1]}
-              >
-                승인
-              </Slider.OptionItem>
-            </>
-          ) : (
-            <Slider.OptionItem
-              index={1}
-              isAccept={false}
-              onClick={handleClickOption[transmitStatus][0]}
-            >
-              취소
-            </Slider.OptionItem>
-          )}
+          <Slider.OptionItem backgroundColor='#8e8e8e'>
+            <span onClick={handleClickOption[transmitStatus][0]}>거절</span>
+          </Slider.OptionItem>
+
+          <Slider.OptionItem backgroundColor='tomato'>
+            <span onClick={handleClickOption[transmitStatus][1]}>승인</span>
+          </Slider.OptionItem>
         </Slider.Options>
-      </Slider.Inner>
+      ) : (
+        <Slider.Options>
+          <Slider.OptionItem backgroundColor='#8e8e8e'>
+            <span onClick={handleClickOption[transmitStatus][0]}>취소</span>
+          </Slider.OptionItem>
+        </Slider.Options>
+      )}
     </Slider>
   );
 };

--- a/frontend/src/pages/Reservations/components/ListReservationItem.tsx
+++ b/frontend/src/pages/Reservations/components/ListReservationItem.tsx
@@ -20,10 +20,7 @@ const ListReservationItem = ({
   reservationId,
   transmitStatus,
 }: ListReservationItemProps) => {
-  const { acceptRequest, cancelRequest, denyRequest } = useListReservationItem({
-    reservationId,
-    time,
-  });
+  const { acceptRequest, cancelRequest, denyRequest } = useListReservationItem(reservationId);
 
   return (
     <Slider>

--- a/frontend/src/pages/Reservations/components/ListReservationItem.tsx
+++ b/frontend/src/pages/Reservations/components/ListReservationItem.tsx
@@ -3,6 +3,7 @@ import { CouponTransmitStatus, CouponType } from '../../../types/coupon';
 import { MeetingTime } from '../../../types/meeting';
 import Slider from '../../../components/@shared/ChoiceSlider';
 import ListViewReservationDetail from './ListViewReservation';
+import styled from '@emotion/styled';
 
 type ListReservationItemProps = {
   couponType: CouponType;
@@ -19,7 +20,10 @@ const ListReservationItem = ({
   reservationId,
   transmitStatus,
 }: ListReservationItemProps) => {
-  const { handleClickOption } = useListReservationItem({ reservationId, time });
+  const { acceptRequest, cancelRequest, denyRequest } = useListReservationItem({
+    reservationId,
+    time,
+  });
 
   return (
     <Slider>
@@ -33,18 +37,17 @@ const ListReservationItem = ({
       </Slider.Toggle>
       {transmitStatus === 'received' ? (
         <Slider.Options>
-          <Slider.OptionItem backgroundColor='#8e8e8e'>
-            <span onClick={handleClickOption[transmitStatus][0]}>거절</span>
+          <Slider.OptionItem>
+            <Reject onClick={denyRequest}>거절</Reject>
           </Slider.OptionItem>
-
-          <Slider.OptionItem backgroundColor='tomato'>
-            <span onClick={handleClickOption[transmitStatus][1]}>승인</span>
+          <Slider.OptionItem>
+            <Accept onClick={acceptRequest}>승낙</Accept>
           </Slider.OptionItem>
         </Slider.Options>
       ) : (
         <Slider.Options>
-          <Slider.OptionItem backgroundColor='#8e8e8e'>
-            <span onClick={handleClickOption[transmitStatus][0]}>취소</span>
+          <Slider.OptionItem>
+            <Reject onClick={cancelRequest}>취소</Reject>
           </Slider.OptionItem>
         </Slider.Options>
       )}
@@ -53,3 +56,19 @@ const ListReservationItem = ({
 };
 
 export default ListReservationItem;
+
+const OptionItem = styled.span`
+  color: white;
+  display: grid;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  text-align: right;
+  padding-right: 3%;
+`;
+const Reject = styled(OptionItem)`
+  background-color: #8e8e8e;
+`;
+const Accept = styled(OptionItem)`
+  background-color: tomato;
+`;

--- a/frontend/src/pages/Reservations/hooks/useListReservationItem.ts
+++ b/frontend/src/pages/Reservations/hooks/useListReservationItem.ts
@@ -1,5 +1,4 @@
 import { useQueryClient } from 'react-query';
-import { MeetingTime } from '../../../types/meeting';
 import {
   RESERVATION_QUERY_KEYS,
   usePutCancelReseravation,
@@ -8,12 +7,7 @@ import {
 import { 예약요청응답별코멘트 } from '../../Main/hooks/useCouponDetail';
 import useToast from '../../../hooks/useToast';
 
-type useListReservationItemProps = {
-  reservationId: number;
-  time: MeetingTime;
-};
-
-const useListReservationItem = ({ reservationId, time }: useListReservationItemProps) => {
+const useListReservationItem = (reservationId: number) => {
   const queryClient = useQueryClient();
   const { insertToastItem } = useToast();
 
@@ -44,7 +38,7 @@ const useListReservationItem = ({ reservationId, time }: useListReservationItemP
       }
     },
     acceptRequest: () => {
-      if (confirm(`예약을 수락하시겠습니까? \n ${time?.meetingTime}`)) {
+      if (confirm(`예약을 수락하시겠습니까?`)) {
         handleReservation('accept');
       }
     },

--- a/frontend/src/pages/Reservations/hooks/useListReservationItem.ts
+++ b/frontend/src/pages/Reservations/hooks/useListReservationItem.ts
@@ -37,28 +37,22 @@ const useListReservationItem = ({ reservationId, time }: useListReservationItemP
     },
   });
 
-  const handleClickOption = {
-    received: [
-      () => {
-        if (confirm('예약을 거절하시겠습니까?')) {
-          handleReservation('deny');
-        }
-      },
-      () => {
-        if (confirm(`예약을 수락하시겠습니까? \n ${time?.meetingTime}`)) {
-          handleReservation('accept');
-        }
-      },
-    ],
-    sent: [
-      () => {
-        if (confirm('예약을 취소하시겠습니까?')) {
-          cancelReservation();
-        }
-      },
-    ],
+  return {
+    denyRequest: () => {
+      if (confirm('예약을 거절하시겠습니까?')) {
+        handleReservation('deny');
+      }
+    },
+    acceptRequest: () => {
+      if (confirm(`예약을 수락하시겠습니까? \n ${time?.meetingTime}`)) {
+        handleReservation('accept');
+      }
+    },
+    cancelRequest: () => {
+      if (confirm('예약을 취소하시겠습니까?')) {
+        cancelReservation();
+      }
+    },
   };
-
-  return { handleClickOption };
 };
 export default useListReservationItem;

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -11,7 +11,10 @@ export const engDayTo요일 = {
 };
 
 export const getNowKrLocaleFullDateISOFormat = () =>
-  new Date().toLocaleDateString('ko-KR').replaceAll('. ', '-').replace('.', '') +
+  new Date()
+    .toLocaleDateString('ko-KR', { day: '2-digit', month: '2-digit', year: 'numeric' })
+    .replaceAll('. ', '-')
+    .replace('.', '') +
   ' ' +
   new Date()
     .toLocaleTimeString('ko-KR', { hour12: false })


### PR DESCRIPTION
## 상세 내용
- ChoiceSlider의 z-index를 주는 로직을 수정했습니다.
  - 총 option의 개수 - 해당 index 로 z-index를 줍니다.
  - 기존 사용하는 곳에서 필수적으로 주던 index를 ChoiceSlider 안에서 주도록 숨깁니다.
  - 불필요한 Inner wrapper가 있어서 삭제했습니다.
  - 기존 Content라는 이름을 Toggle로 수정했습니다. UI 컴포넌트 사이트들을 보니 Toggle이란 이름을 많이 쓰는 것을 확인했습니다.
  - 컴포넌트 props에 어느 정도 타입을 줬습니다.
 
 ## 완료하지 못한 내용
- 정확한 타이핑을 하지 못했습니다.
- 가령 Options의 자식으로는 OptionItem이 와야한다. 혹은 Options의 자식은 3개 이하여야 한다 등을 타입으로 주고 싶었으나 잘 안됐습니다.


Close #638 

